### PR TITLE
Rename to truelayer-signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution guidelines
 
-First off, thank you for considering contributing to truelayer-request-signature.
+First off, thank you for considering contributing to truelayer-signing.
 
 If your contribution is not straightforward, please first discuss the change you
 wish to make by creating a new issue before making the change.
@@ -8,7 +8,7 @@ wish to make by creating a new issue before making the change.
 ## Reporting issues
 
 Before reporting an issue on the
-[issue tracker](https://github.com/TrueLayer/truelayer-request-signature/issues),
+[issue tracker](https://github.com/TrueLayer/truelayer-signing/issues),
 please check that it has not already been reported by searching for some related
 keywords.
 
@@ -19,7 +19,7 @@ Try to do one pull request per change.
 ### Updating the changelog
 
 Update the changes you have made in
-[CHANGELOG](https://github.com/TrueLayer/truelayer-request-signature/blob/main/rust/CHANGELOG.md)
+[CHANGELOG](https://github.com/TrueLayer/truelayer-signing/blob/main/rust/CHANGELOG.md)
 file under the **Unreleased** section.
 
 Add the changes of your pull request to one of the following subsections,
@@ -42,7 +42,7 @@ If the required subsection does not exist yet under **Unreleased**, create it!
 Rust code lives in ./rust.
 
 ```shell
-git clone https://github.com/TrueLayer/truelayer-request-signature
-cd truelayer-request-signature/rust
+git clone https://github.com/TrueLayer/truelayer-signing
+cd truelayer-signing/rust
 cargo test
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# truelayer-request-signature
+# truelayer-signing
 Convenient libraries to produce TrueLayer API requests signatures.
 
 Request signatures are created using a private key and included with certain API requests.

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -5,4 +5,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased (0.1.0)
-* Added `truelayer_request_signature::{sign_with_pem, verify_with_pem, extract_jws_header}`.
+* Added `truelayer_signing::{sign_with_pem, verify_with_pem, extract_jws_header}`.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "truelayer-request-signature"
+name = "truelayer-signing"
 version = "0.1.0"
 authors = ["Alex Butler <alex.butler@truelayer.com>"]
 edition = "2018"
 description = "Produce & verify TrueLayer API requests signatures"
-repository = "https://github.com/TrueLayer/truelayer-request-signature"
+repository = "https://github.com/TrueLayer/truelayer-signing"
 keywords = ["truelayer"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,12 +1,12 @@
-# truelayer-request-signature
+# truelayer-signing
 Rust crate to produce & verify TrueLayer API requests signatures.
 
-[![Crates.io](https://img.shields.io/crates/v/truelayer-request-signature.svg)](https://crates.io/crates/truelayer-request-signature)
-[![Docs.rs](https://docs.rs/truelayer-request-signature/badge.svg)](https://docs.rs/truelayer-request-signature)
+[![Crates.io](https://img.shields.io/crates/v/truelayer-signing.svg)](https://crates.io/crates/truelayer-signing)
+[![Docs.rs](https://docs.rs/truelayer-signing/badge.svg)](https://docs.rs/truelayer-signing)
 
 ```rust
 // `Tl-Signature` value to send with the request.
-let tl_signature = truelayer_request_signature::sign_with_pem(kid, private_key)
+let tl_signature = truelayer_signing::sign_with_pem(kid, private_key)
     .method("POST")
     .path("/payouts")
     .header("Idempotency-Key", idempotency_key)

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! # Example
 //! ```no_run
-//! # fn main() -> Result<(), truelayer_request_signature::Error> {
+//! # fn main() -> Result<(), truelayer_signing::Error> {
 //! # let (kid, private_key, idempotency_key, body) = unimplemented!();
 //! // `Tl-Signature` value to send with the request.
-//! let tl_signature = truelayer_request_signature::sign_with_pem(kid, private_key)
+//! let tl_signature = truelayer_signing::sign_with_pem(kid, private_key)
 //!     .method("POST")
 //!     .path("/payouts")
 //!     .header("Idempotency-Key", idempotency_key)
@@ -29,9 +29,9 @@ pub use verify::Verifier;
 ///
 /// # Example
 /// ```no_run
-/// # fn main() -> Result<(), truelayer_request_signature::Error> {
+/// # fn main() -> Result<(), truelayer_signing::Error> {
 /// # let (kid, private_key, idempotency_key, body) = unimplemented!();
-/// let tl_signature = truelayer_request_signature::sign_with_pem(kid, private_key)
+/// let tl_signature = truelayer_signing::sign_with_pem(kid, private_key)
 ///     .method("POST")
 ///     .path("/payouts")
 ///     .header("Idempotency-Key", idempotency_key)
@@ -47,9 +47,9 @@ pub fn sign_with_pem<'a>(kid: &'a str, private_key_pem: &'a str) -> Signer<'a> {
 ///
 /// # Example
 /// ```no_run
-/// # fn main() -> Result<(), truelayer_request_signature::Error> {
+/// # fn main() -> Result<(), truelayer_signing::Error> {
 /// # let (public_key, idempotency_key, body, tl_signature) = unimplemented!();
-/// truelayer_request_signature::verify_with_pem(public_key)
+/// truelayer_signing::verify_with_pem(public_key)
 ///     .method("POST")
 ///     .path("/payouts")
 ///     .require_header("Idempotency-Key")

--- a/rust/tests/usage.rs
+++ b/rust/tests/usage.rs
@@ -8,12 +8,12 @@ const KID: &str = "45fc75cf-5649-4134-84b3-192c2c78e990";
 fn body_signature() {
     let body = br#"{"abc":123}"#;
 
-    let tl_signature = truelayer_request_signature::sign_with_pem(KID, PRIVATE_KEY)
+    let tl_signature = truelayer_signing::sign_with_pem(KID, PRIVATE_KEY)
         .body(body)
         .sign_body_only()
         .expect("sign_body");
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .body(body)
         .verify(&tl_signature)
         .expect("verify");
@@ -21,12 +21,12 @@ fn body_signature() {
 
 #[test]
 fn body_signature_mismatch() {
-    let tl_signature = truelayer_request_signature::sign_with_pem(KID, PRIVATE_KEY)
+    let tl_signature = truelayer_signing::sign_with_pem(KID, PRIVATE_KEY)
         .body(br#"{"abc":123}"#)
         .sign_body_only()
         .expect("sign_body");
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .body(br#"{"abc":124}"#) // different
         .verify(&tl_signature)
         .expect_err("verify should fail");
@@ -37,7 +37,7 @@ fn verify_body_static_signature() {
     let body = br#"{"abc":123}"#;
     let tl_signature = "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2NDktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCJ9..AdDESSiHQVQSRFrD8QO6V8m0CWIfsDGyMOlipOt9LQhyG1lKjDR17crBgy_7TYi4ZQH--dyNtN9Nab3P7yFQzgqOALl8S-beevWYpnIMXHQCgrv-XpfNtenJTckCH2UAQIwR-pjV8XiTM1be1RMYpMl8qYTbCL5Bf8t_dME-1E6yZQEH";
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .body(body)
         .verify(tl_signature)
         .expect("verify");
@@ -50,7 +50,7 @@ fn full_request_signature() {
     let idempotency_key = "idemp-2076717c-9005-4811-a321-9e0787fa0382";
     let path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
 
-    let tl_signature = truelayer_request_signature::sign_with_pem(KID, PRIVATE_KEY)
+    let tl_signature = truelayer_signing::sign_with_pem(KID, PRIVATE_KEY)
         .method("post")
         .path(path)
         .header("Idempotency-Key", idempotency_key)
@@ -58,7 +58,7 @@ fn full_request_signature() {
         .sign()
         .expect("sign");
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .method("POST")
         .path(path)
         .require_header("Idempotency-Key")
@@ -76,7 +76,7 @@ fn verify_full_request_static_signature() {
     let path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
     let tl_signature = "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2NDktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGVhZGVycyI6IklkZW1wb3RlbmN5LUtleSJ9..AfhpFccUCUKEmotnztM28SUYgMnzPNfDhbxXUSc-NByYc1g-rxMN6HS5g5ehiN5yOwb0WnXPXjTCuZIVqRvXIJ9WAPr0P9R68ro2rsHs5HG7IrSufePXvms75f6kfaeIfYKjQTuWAAfGPAeAQ52PNQSd5AZxkiFuCMDvsrnF5r0UQsGi";
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .method("POST")
         .path(path)
         .header("X-Whatever-2", "t2345d")
@@ -92,7 +92,7 @@ fn full_request_signature_method_mismatch() {
     let idempotency_key = "idemp-2076717c-9005-4811-a321-9e0787fa0382";
     let path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
 
-    let tl_signature = truelayer_request_signature::sign_with_pem(KID, PRIVATE_KEY)
+    let tl_signature = truelayer_signing::sign_with_pem(KID, PRIVATE_KEY)
         .method("post")
         .path(path)
         .header("Idempotency-Key", idempotency_key)
@@ -100,7 +100,7 @@ fn full_request_signature_method_mismatch() {
         .sign()
         .expect("sign");
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .method("DELETE") // different
         .path(path)
         .header("X-Whatever", "aoitbeh")
@@ -116,7 +116,7 @@ fn full_request_signature_path_mismatch() {
     let idempotency_key = "idemp-2076717c-9005-4811-a321-9e0787fa0382";
     let path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
 
-    let tl_signature = truelayer_request_signature::sign_with_pem(KID, PRIVATE_KEY)
+    let tl_signature = truelayer_signing::sign_with_pem(KID, PRIVATE_KEY)
         .method("post")
         .path(path)
         .header("Idempotency-Key", idempotency_key)
@@ -124,7 +124,7 @@ fn full_request_signature_path_mismatch() {
         .sign()
         .expect("sign");
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .method("post")
         .path("/merchant_accounts/67b5b1cf-1d0c-45d4-a2ea-61bdc044327c/sweeping") // different
         .header("X-Whatever", "aoitbeh")
@@ -140,7 +140,7 @@ fn full_request_signature_header_mismatch() {
     let idempotency_key = "idemp-2076717c-9005-4811-a321-9e0787fa0382";
     let path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
 
-    let tl_signature = truelayer_request_signature::sign_with_pem(KID, PRIVATE_KEY)
+    let tl_signature = truelayer_signing::sign_with_pem(KID, PRIVATE_KEY)
         .method("post")
         .path(path)
         .header("Idempotency-Key", idempotency_key)
@@ -148,7 +148,7 @@ fn full_request_signature_header_mismatch() {
         .sign()
         .expect("sign");
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .method("post")
         .path(path)
         .header("X-Whatever", "aoitbeh")
@@ -164,7 +164,7 @@ fn full_request_signature_body_mismatch() {
     let idempotency_key = "idemp-2076717c-9005-4811-a321-9e0787fa0382";
     let path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
 
-    let tl_signature = truelayer_request_signature::sign_with_pem(KID, PRIVATE_KEY)
+    let tl_signature = truelayer_signing::sign_with_pem(KID, PRIVATE_KEY)
         .method("post")
         .path(path)
         .header("Idempotency-Key", idempotency_key)
@@ -172,7 +172,7 @@ fn full_request_signature_body_mismatch() {
         .sign()
         .expect("sign");
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .method("post")
         .path(path)
         .header("X-Whatever", "aoitbeh")
@@ -188,7 +188,7 @@ fn full_request_signature_missing_signature_header() {
     let idempotency_key = "idemp-2076717c-9005-4811-a321-9e0787fa0382";
     let path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
 
-    let tl_signature = truelayer_request_signature::sign_with_pem(KID, PRIVATE_KEY)
+    let tl_signature = truelayer_signing::sign_with_pem(KID, PRIVATE_KEY)
         .method("post")
         .path(path)
         .header("Idempotency-Key", idempotency_key)
@@ -196,7 +196,7 @@ fn full_request_signature_missing_signature_header() {
         .sign()
         .expect("sign");
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .method("post")
         .path(path)
         .header("X-Whatever", "aoitbeh")
@@ -212,7 +212,7 @@ fn full_request_signature_required_header_missing_from_signature() {
     let idempotency_key = "idemp-2076717c-9005-4811-a321-9e0787fa0382";
     let path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
 
-    let tl_signature = truelayer_request_signature::sign_with_pem(KID, PRIVATE_KEY)
+    let tl_signature = truelayer_signing::sign_with_pem(KID, PRIVATE_KEY)
         .method("post")
         .path(path)
         .header("Idempotency-Key", idempotency_key)
@@ -220,7 +220,7 @@ fn full_request_signature_required_header_missing_from_signature() {
         .sign()
         .expect("sign");
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .method("post")
         .path(path)
         .require_header("X-Required") // missing from signature
@@ -236,7 +236,7 @@ fn flexible_header_case_order_verify() {
     let idempotency_key = "idemp-2076717c-9005-4811-a321-9e0787fa0382";
     let path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
 
-    let tl_signature = truelayer_request_signature::sign_with_pem(KID, PRIVATE_KEY)
+    let tl_signature = truelayer_signing::sign_with_pem(KID, PRIVATE_KEY)
         .method("post")
         .path(path)
         .header("Idempotency-Key", idempotency_key)
@@ -245,7 +245,7 @@ fn flexible_header_case_order_verify() {
         .sign()
         .expect("sign");
 
-    truelayer_request_signature::verify_with_pem(PUBLIC_KEY)
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
         .method("post")
         .path(path)
         .header("X-CUSTOM", "123") // different order & case, it's ok!
@@ -257,7 +257,7 @@ fn flexible_header_case_order_verify() {
 
 #[test]
 fn extract_jws_header() {
-    let tl_signature = truelayer_request_signature::sign_with_pem(KID, PRIVATE_KEY)
+    let tl_signature = truelayer_signing::sign_with_pem(KID, PRIVATE_KEY)
         .method("delete")
         .path("/foo")
         .header("X-Custom", "123")
@@ -265,7 +265,7 @@ fn extract_jws_header() {
         .expect("sign");
 
     let jws_header =
-        truelayer_request_signature::extract_jws_header(&tl_signature).expect("extract_jws_header");
+        truelayer_signing::extract_jws_header(&tl_signature).expect("extract_jws_header");
 
     assert_eq!(jws_header.alg, "ES512");
     assert_eq!(jws_header.kid, KID);


### PR DESCRIPTION
Rename to `truelayer-signing` (I'll rename the repo too after merging).

Any other name ideas?