### PR TITLE
Use key pem `&[u8]` instead of `&str`

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -39,7 +39,7 @@ pub use verify::Verifier;
 ///     .sign()?;
 /// # Ok(()) }
 /// ```
-pub fn sign_with_pem<'a>(kid: &'a str, private_key_pem: &'a str) -> Signer<'a> {
+pub fn sign_with_pem<'a>(kid: &'a str, private_key_pem: &'a [u8]) -> Signer<'a> {
     Signer::new(kid, private_key_pem)
 }
 
@@ -58,7 +58,7 @@ pub fn sign_with_pem<'a>(kid: &'a str, private_key_pem: &'a str) -> Signer<'a> {
 ///     .verify(tl_signature)?;
 /// # Ok(()) }
 /// ```
-pub fn verify_with_pem(public_key_pem: &str) -> Verifier<'_> {
+pub fn verify_with_pem(public_key_pem: &[u8]) -> Verifier<'_> {
     Verifier::new(public_key_pem)
 }
 

--- a/rust/src/verify.rs
+++ b/rust/src/verify.rs
@@ -12,7 +12,7 @@ use std::fmt;
 
 /// Builder to verify a request against a `Tl-Signature` header.
 pub struct Verifier<'a> {
-    public_key: &'a str,
+    public_key: &'a [u8],
     body: &'a [u8],
     method: &'a str,
     path: &'a str,
@@ -28,7 +28,7 @@ impl fmt::Debug for Verifier<'_> {
 }
 
 impl<'a> Verifier<'a> {
-    pub(crate) fn new(public_key: &'a str) -> Self {
+    pub(crate) fn new(public_key: &'a [u8]) -> Self {
         Self {
             public_key,
             body: &[],
@@ -94,7 +94,7 @@ impl<'a> Verifier<'a> {
     /// Returns `Err(_)` if verification fails.
     pub fn verify(&self, tl_signature: &str) -> Result<(), Error> {
         let public_key =
-            openssl::parse_ec_public_key(self.public_key.as_bytes()).map_err(Error::InvalidKey)?;
+            openssl::parse_ec_public_key(self.public_key).map_err(Error::InvalidKey)?;
 
         let (jws_header, header_b64, signature) = parse_tl_signature(tl_signature)?;
 

--- a/rust/tests/usage.rs
+++ b/rust/tests/usage.rs
@@ -1,5 +1,5 @@
-const PUBLIC_KEY: &str = include_str!("ec512-public.pem");
-const PRIVATE_KEY: &str = include_str!("ec512-private.pem");
+const PUBLIC_KEY: &[u8] = include_bytes!("ec512-public.pem");
+const PRIVATE_KEY: &[u8] = include_bytes!("ec512-private.pem");
 // we already know the public key, so the kid can be anything in these tests.
 const KID: &str = "45fc75cf-5649-4134-84b3-192c2c78e990";
 


### PR DESCRIPTION
For users its easier to go from `&str` -> `&[u8]` than vice-versa and we actually just need `&[u8]`.