### PR TITLE
Fix C# allowing signatures with attached bodies + support C# & nodejs no-header usage

### DIFF
--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -150,10 +150,12 @@ namespace TrueLayer.Signing
 
             SignatureException.Ensure(jwsHeaders["alg"] as string == "ES512", "unsupported jws alg");
             SignatureException.Ensure(jwsHeaders["tl_version"] as string == "2", "unsupported jws tl_version");
+            SignatureException.Ensure(tlSignature.Contains(".."), "signature must have a detached payload");
 
             var signatureHeaderNames = (jwsHeaders["tl_headers"] as string ?? "")
                 .Split(",")
                 .Select(h => h.Trim())
+                .Where(h => !string.IsNullOrEmpty(h))
                 .ToList();
 
             var missingRequired = requiredHeaders.SingleOrDefault(h => !signatureHeaderNames.Contains(h));

--- a/csharp/test/ErrorTest.cs
+++ b/csharp/test/ErrorTest.cs
@@ -32,5 +32,26 @@ namespace Tests
 
             verify.Should().Throw<SignatureException>();
         }
+
+        [Fact]
+        public void InvalidButPreAttachedJwsBody()
+        {
+            // signature for `/bar` but with a valid jws-body pre-attached
+            // if we run verify on this unchanged it'll work!
+            const string Signature = "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2ND"
+                + "ktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGV"
+                + "hZGVycyI6IiJ9.UE9TVCAvYmFyCnt9.ARLa7Q5b8k5CIhfy1qrS-IkNqCDeE-VFRD"
+                + "z7Lb0fXUMOi_Ktck-R7BHDMXFDzbI5TyaxIo5TGHZV_cs0fg96dlSxAERp3UaN2oC"
+                + "QHIE5gQ4m5uU3ee69XfwwU_RpEIMFypycxwq1HOf4LzTLXqP_CDT8DdyX8oTwYdUB"
+                + "d2d3D17Wd9UA";
+
+            Action verify = () => Verifier.VerifyWithPem(PublicKey)
+                .Method("post")
+                .Path("/foo") // not /bar so should fail
+                .Body("{}")
+                .Verify(Signature);
+
+            verify.Should().Throw<SignatureException>();
+        }
     }
 }

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -47,6 +47,25 @@ namespace Tests
                 .Verify(tlSignature); // should not throw
         }
 
+        [Fact]
+        public void SignAndVerify_NoHeaders()
+        {
+            var body = "{\"currency\":\"GBP\",\"max_amount_in_minor\":5000000}";
+            var path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
+
+            var tlSignature = Signer.SignWithPem(Kid, PrivateKey)
+                .Method("POST")
+                .Path(path)
+                .Body(body)
+                .Sign();
+
+            Verifier.VerifyWithPem(PublicKey)
+                .Method("POST") 
+                .Path(path)
+                .Body(body)
+                .Verify(tlSignature); // should not throw
+        }
+
         // Verify the a static signature used in all lang tests to ensure
         // cross-lang consistency and prevent regression.
         [Fact]

--- a/javascript/lib/lib.js
+++ b/javascript/lib/lib.js
@@ -106,7 +106,7 @@ module.exports = {
     const headers = new Headers(args.headers || {}).validated();
 
     const { headerJson, header, footer } = parseSignature(signature);
-    const tlHeaders = (headerJson.tl_headers || "").split(",");
+    const tlHeaders = (headerJson.tl_headers || "").split(",").filter(h => !!h);
 
     // fail if signature is missing a required header
     for (const required of requiredHeaders) {

--- a/javascript/test/usage.js
+++ b/javascript/test/usage.js
@@ -67,6 +67,51 @@ describe('verify', () => {
     });
   });
 
+  it('should not throw using a signature with no headers', () => {
+    const body = '{"currency":"GBP","max_amount_in_minor":5000000}';
+    const path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
+
+    const signature = sign({
+      kid: KID,
+      privateKeyPem: PRIVATE_KEY,
+      method: "post",
+      path,
+      body,
+    });
+
+    verify({
+      publicKeyPem: PUBLIC_KEY,
+      signature,
+      method: "post",
+      path,
+      body,
+      headers: {
+        "X-Whatever-2": "foaulrsjth",
+      }
+    })
+  });
+
+  it('should throw using a mismatched signature that has an attached valid body', () => {
+    // signature for `/bar` but with a valid jws-body pre-attached
+    // if we run a simple jws verify on this unchanged it'll work!
+    const signature = "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2ND"
+      + "ktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGV"
+      + "hZGVycyI6IiJ9.UE9TVCAvYmFyCnt9.ARLa7Q5b8k5CIhfy1qrS-IkNqCDeE-VFRD"
+      + "z7Lb0fXUMOi_Ktck-R7BHDMXFDzbI5TyaxIo5TGHZV_cs0fg96dlSxAERp3UaN2oC"
+      + "QHIE5gQ4m5uU3ee69XfwwU_RpEIMFypycxwq1HOf4LzTLXqP_CDT8DdyX8oTwYdUB"
+      + "d2d3D17Wd9UA";
+
+    assert.throws(
+      () => verify({
+        publicKeyPem: PUBLIC_KEY,
+        signature,
+        method: "post",
+        path: "/foo", // not /bar so should fail
+        body: "{}"
+      })
+    );
+  });
+
   it('should throw using a signature with mismatched method', () => {
     const body = '{"currency":"GBP","max_amount_in_minor":5000000}';
     const idempotencyKey = "idemp-2076717c-9005-4811-a321-9e0787fa0382";


### PR DESCRIPTION
Signatures are supposed to have detached bodies. We then populate the body during verification. However, if you send jws with an attached valid body, that otherwise would have failed validation the C# verify logic allowed it, as `.Replace("..", ...)` silently did nothing.

This pr fixes that, the C# lib requires detached jws signatures or throws a `SignatureException`.

Nodejs & rust were not vulnerable to this, but now have similar scenario tests to cover this.

### Support for signatures without any headers
I also found the nodejs & C# verifiers were requiring at least some headers. Otherwise they would fail requiring the empty string `""` header. All 3 langs now have scenarios ensuring that no-header usage is allowed.