### PR TITLE
C# throw SignatureException for missing jws headers

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 * Add `Verifier` support for signatures without headers.
 * Fix `Verifier` allowing non-detached jws signatures.
+* Fix `Verifier` to throw `SignatureException`s when signature jws headers are missing
+  (instead of `KeyNotFoundException`).
 
 ## 0.1.1
 * Fix changelog path in PackageReleaseNotes.

--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Add `Verifier` support for signatures without headers.
+* Fix `Verifier` allowing non-detached jws signatures.
+
 ## 0.1.1
 * Fix changelog path in PackageReleaseNotes.
 * Build in release mode & add symbols to package.

--- a/csharp/src/Util.cs
+++ b/csharp/src/Util.cs
@@ -117,6 +117,16 @@ namespace TrueLayer.Signing
                 throw new ArgumentException($"Invalid key pem data: {e.Message}");
             }
         }
+
+        /// <summary>Gets a value from the map as a string or null.</summary>
+        public static string? GetString(this IDictionary<string, object> dict, string key)
+        {
+            if (dict.TryGetValue(key, out var value))
+            {
+                return value as string;
+            }
+            return null;
+        }
     }
 
     /// <summary>Case-insensitive string header name comparison.</summary>

--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -148,11 +148,11 @@ namespace TrueLayer.Signing
         {
             var jwsHeaders = SignatureException.Try(() => Jose.JWT.Headers(tlSignature));
 
-            SignatureException.Ensure(jwsHeaders["alg"] as string == "ES512", "unsupported jws alg");
-            SignatureException.Ensure(jwsHeaders["tl_version"] as string == "2", "unsupported jws tl_version");
+            SignatureException.Ensure(jwsHeaders.GetString("alg") == "ES512", "unsupported jws alg");
+            SignatureException.Ensure(jwsHeaders.GetString("tl_version") == "2", "unsupported jws tl_version");
             SignatureException.Ensure(tlSignature.Contains(".."), "signature must have a detached payload");
 
-            var signatureHeaderNames = (jwsHeaders["tl_headers"] as string ?? "")
+            var signatureHeaderNames = (jwsHeaders.GetString("tl_headers") ?? "")
                 .Split(",")
                 .Select(h => h.Trim())
                 .Where(h => !string.IsNullOrEmpty(h))

--- a/csharp/test/ErrorTest.cs
+++ b/csharp/test/ErrorTest.cs
@@ -53,5 +53,24 @@ namespace Tests
 
             verify.Should().Throw<SignatureException>();
         }
+
+         [Fact]
+        public void MissingJwsHeaders()
+        {
+            // jws headers are lacking bits we need
+            const string Signature = "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2ND"
+                + "ktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCIsInRsX2hlYWRlcnMiOiIifQ..AHrNENw"
+                + "CMqQ_kDEQZiXeXsLxgXCDn-62b_Oh1yEPKsE8n1-qC3EIpA360WeCJXMyeMVH3FKi"
+                + "aJ1A1px7AnmzUIpeATgzbPSlWjyB-q2e--XeyOhausFq0BCWWfHbhlyGkjfk9zkBq"
+                + "XXd2iibbLPvId-tL50UhNBKNse_EMoKsW_Lav7D";
+
+            Action verify = () => Verifier.VerifyWithPem(PublicKey)
+                .Method("POST")
+                .Path("/foo")
+                .Body("{}")
+                .Verify(Signature);
+
+            verify.Should().Throw<SignatureException>();
+        }
     }
 }

--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -4,5 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Add `verify` support for signatures without headers.
+
 ## 0.1.0
 * Added `sign`, `verify`, `extractKid` methods.


### PR DESCRIPTION
C# verify currently throws `System.Collections.Generic.KeyNotFoundException` if required jws header fields are missing, such as `tl_version` or `alg`. This pr instead throws `SignatureException` to handle these simply as invalid signatures.