### PR TITLE
rust: support `jku` jws header

### DIFF
--- a/rust/src/jws.rs
+++ b/rust/src/jws.rs
@@ -18,10 +18,17 @@ pub struct JwsHeader {
     /// Comma separated ordered headers used in the signature.
     #[serde(default)]
     pub tl_headers: String,
+    /// JSON Web Key URL. Used in webhook signatures providing the public key jwk url.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub jku: Option<String>,
 }
 
 impl JwsHeader {
-    pub(crate) fn new_v2(kid: &str, headers: &IndexMap<HeaderName<'_>, &[u8]>) -> Self {
+    pub(crate) fn new_v2(
+        kid: &str,
+        headers: &IndexMap<HeaderName<'_>, &[u8]>,
+        jku: Option<String>,
+    ) -> Self {
         let header_keys = headers.keys().fold(String::new(), |mut all, next| {
             if !all.is_empty() {
                 all.push(',');
@@ -34,6 +41,7 @@ impl JwsHeader {
             kid: kid.into(),
             tl_version: "2".into(),
             tl_headers: header_keys,
+            jku,
         }
     }
 

--- a/rust/tests/usage.rs
+++ b/rust/tests/usage.rs
@@ -317,6 +317,7 @@ fn extract_jws_header() {
         .method("delete")
         .path("/foo")
         .header("X-Custom", b"123")
+        .jku("https://webhooks.truelayer.com/.well-known/jwks")
         .sign()
         .expect("sign");
 
@@ -327,4 +328,8 @@ fn extract_jws_header() {
     assert_eq!(jws_header.kid, KID);
     assert_eq!(jws_header.tl_version, "2");
     assert_eq!(jws_header.tl_headers, "X-Custom");
+    assert_eq!(
+        jws_header.jku.as_deref(),
+        Some("https://webhooks.truelayer.com/.well-known/jwks")
+    );
 }


### PR DESCRIPTION
When signing webhooks we want to also include a `jku` JSON Web Key URL which will be used to lookup the jwk public key to verify webhooks.

This PR supports adding a `jku` when signing & extracting it out of a signature using the rust lib. The former does not need wide support as clients will not need to set `jku` for regular requests. We should probably add extracting the jku to all langs though.

This is a non-breaking change.