### PR TITLE
C# Add `Verifier.VerifyWithJwks`, `Verifier.ExtractJku`

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 * Add `Verifier.ExtractJku` to extract `jku` jws header from webhook signatures.
+* Add `Verifier.VerifyWithJwks` to aid verifying webhook signatures.
 
 ## 0.1.2
 * Add `Verifier` support for signatures without headers.

--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+* Add `Verifier.ExtractJku` to extract `jku` jws header from webhook signatures.
+
 ## 0.1.2
 * Add `Verifier` support for signatures without headers.
 * Fix `Verifier` allowing non-detached jws signatures.

--- a/csharp/src/Util.cs
+++ b/csharp/src/Util.cs
@@ -36,6 +36,18 @@ namespace TrueLayer.Signing
             }
         }
 
+        /// <summary>
+        /// Run the action converting any thrown exception into a SignatureException.
+        /// </summary>
+        internal static void TryAction(Action f, string? message = null)
+        {
+            Try(() =>
+            {
+                f();
+                return (object?) null;
+            }, message);
+        }
+
         internal SignatureException(string message) : base(message) { }
         internal SignatureException(string message, Exception? innerException) : base(message, innerException) { }
     }
@@ -136,5 +148,21 @@ namespace TrueLayer.Signing
             => string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
 
         public int GetHashCode(string x) => x.ToLowerInvariant().GetHashCode();
+    }
+
+    /// <summary>JWKs json object.</summary>
+    internal class Jwks
+    {
+        public List<Jwk> Keys { get; set; } = new List<Jwk>();
+    }
+
+    internal class Jwk
+    {
+        public string Kid { get; set; } = "";
+        public string Kty { get; set; } = "";
+        public string Alg { get; set; } = "";
+        public string Crv { get; set; } = "";
+        public string X { get; set; } = "";
+        public string Y { get; set; } = "";
     }
 }

--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -31,12 +31,27 @@ namespace TrueLayer.Signing
         /// <exception cref="SignatureException">Signature is invalid</exception>
         public static string ExtractKid(string tlSignature)
         {
-            var kid = Jose.JWT.Headers(tlSignature)["kid"] as string;
+            var kid = Jose.JWT.Headers(tlSignature).GetString("kid");
             if (kid == null)
             {
                 throw new SignatureException("missing kid");
             }
             return kid;
+        }
+
+        /// <summary>
+        /// Extract jku (JSON Web Key URL) from unverified jws Tl-Signature.
+        /// Used in webhook signatures providing the public key jwk url.
+        /// </summary>
+        /// <exception cref="SignatureException">Signature is invalid</exception>
+        public static string ExtractJku(string tlSignature)
+        {
+            var jku = Jose.JWT.Headers(tlSignature).GetString("jku");
+            if (jku == null)
+            {
+                throw new SignatureException("missing jku");
+            }
+            return jku;
         }
 
         private ECDsa key;

--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using Jose;
 
 namespace TrueLayer.Signing
@@ -23,6 +24,35 @@ namespace TrueLayer.Signing
         /// </summary>
         public static Verifier VerifyWithPem(ReadOnlySpan<byte> publicKeyPem)
             => VerifyWithPem(Encoding.UTF8.GetString(publicKeyPem));
+
+        /// <summary>
+        /// Start building a `Tl-Signature` header verifier using public key JWKs JSON response data.
+        /// </summary>
+        /// <exception cref="SignatureException">Jwks is invalid</exception>
+        public static Verifier VerifyWithJwks(string jwksJson) => VerifyWithJwks(jwksJson.ToUtf8());
+
+        /// <summary>
+        /// Start building a `Tl-Signature` header verifier using public key JWKs JSON response data.
+        /// </summary>
+        /// <exception cref="SignatureException">Jwks is invalid</exception>
+        public static Verifier VerifyWithJwks(ReadOnlySpan<byte> jwksJson)
+        {
+            try
+            {
+                var jwks = JsonSerializer.Deserialize<Jwks>(jwksJson, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                });
+                // ecdsa fully setup later once we know the jwk kid
+                var verifier = VerifyWith(ECDsa.Create());
+                verifier.jwks = jwks ?? new Jwks();
+                return verifier;
+            }
+            catch (JsonException e)
+            {
+                throw new SignatureException("invalid jwks", e);
+            }
+        }
 
         /// <summary>Start building a `Tl-Signature` header verifier usinga a public key.</summary>
         public static Verifier VerifyWith(ECDsa publicKey) => new Verifier(publicKey);
@@ -55,6 +85,9 @@ namespace TrueLayer.Signing
         }
 
         private ECDsa key;
+        // Non-null when verifying using jwks data.
+        // This indicates we need to initialize `key` once we have the kid.
+        private Jwks? jwks;
         private string method = "";
         private string path = "";
         private Dictionary<string, byte[]> headers = new Dictionary<string, byte[]>(new HeaderNameComparer());
@@ -163,6 +196,13 @@ namespace TrueLayer.Signing
         {
             var jwsHeaders = SignatureException.Try(() => Jose.JWT.Headers(tlSignature));
 
+            if (jwks is Jwks jwkeys)
+            {
+                // initialize public key using jwks data
+                var kid = jwsHeaders.GetString("kid") ?? throw new SignatureException("missing kid");
+                FindAndImportJwk(jwkeys, kid);
+            }
+
             SignatureException.Ensure(jwsHeaders.GetString("alg") == "ES512", "unsupported jws alg");
             SignatureException.Ensure(jwsHeaders.GetString("tl_version") == "2", "unsupported jws tl_version");
             SignatureException.Ensure(tlSignature.Contains(".."), "signature must have a detached payload");
@@ -182,6 +222,26 @@ namespace TrueLayer.Signing
             var jws = tlSignature.Replace("..", $".{Base64Url.Encode(signingPayload)}.");
 
             SignatureException.Try(() => Jose.JWT.Decode(jws, key), "Invalid signature");
+        }
+
+        /// <summary>Find and import jwk into `key`</summary>
+        private void FindAndImportJwk(Jwks jwks, string kid)
+        {
+            var jwk = SignatureException.Try(() => jwks.Keys.First(key => key.Kid == kid), "no jwk found with kid");
+
+            SignatureException.Ensure(jwk.Kty == "EC", "unsupported jwk.kty");
+            SignatureException.Ensure(jwk.Alg == "EC", "unsupported jwk.alg");
+            SignatureException.Ensure(jwk.Crv == "P-521", "unsupported jwk.crv");
+
+            SignatureException.TryAction(() => key.ImportParameters(new ECParameters
+            {
+                Curve = ECCurve.CreateFromFriendlyName("secp521r1"),
+                Q = new ECPoint
+                {
+                    X = Base64Url.Decode(jwk.X),
+                    Y = Base64Url.Decode(jwk.Y),
+                }
+            }), "invalid jwk data");
         }
 
         /// <summary>Filter and order headers to match jws header `tl_headers`.</summary>

--- a/csharp/test/ErrorTest.cs
+++ b/csharp/test/ErrorTest.cs
@@ -11,9 +11,9 @@ namespace Tests
 {
     public class ErrorTest
     {
-        private const string PublicKey = UsageTest.PublicKey;
-        private const string PrivateKey = UsageTest.PrivateKey;
         private const string Kid = UsageTest.Kid;
+        private static string PublicKey = UsageTest.PublicKey;
+        private static string PrivateKey = UsageTest.PrivateKey;
 
         [Fact]
         public void BadKey()

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -2,6 +2,7 @@ using Xunit;
 using TrueLayer.Signing;
 using System;
 using FluentAssertions;
+using System.IO;
 
 namespace Tests
 {
@@ -60,7 +61,7 @@ namespace Tests
                 .Sign();
 
             Verifier.VerifyWithPem(PublicKey)
-                .Method("POST") 
+                .Method("POST")
                 .Path(path)
                 .Body(body)
                 .Verify(tlSignature); // should not throw
@@ -265,5 +266,16 @@ namespace Tests
 
             Verifier.ExtractKid(tlSignature).Should().Be(Kid);
         }
+
+        [Fact]
+        public void Verifier_ExtractJku()
+        {
+            var tlSignature = File.ReadAllText(TestResourcePath("webhook-signature.txt")).Trim();
+            Verifier.ExtractJku(tlSignature).Should().Be("https://webhooks.truelayer.com/.well-known/jwks");
+        }
+
+        /// <summary>Return working path to /test-resources/$subpath</summary>
+        private static string TestResourcePath(string subpath)
+            => Path.Combine("../../../../../test-resources", subpath);
     }
 }

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -3,27 +3,15 @@ using TrueLayer.Signing;
 using System;
 using FluentAssertions;
 using System.IO;
+using System.Text;
 
 namespace Tests
 {
     public class UsageTest
     {
-        // Note: Should be the same keys used in all lang tests
-        //       so static signature tests ensure cross-lang consistency.
-        internal const string PublicKey = "-----BEGIN PUBLIC KEY-----\n"
-            + "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBVIVnghUzHmCEZ3HNjDmaZMJ7UwZf\n"
-            + "av2SYcEtbDQc4uPhiEwWoYZMxzgvsz1vVGkusfTIjcXeCfDZ+xu9grRYt4kBo39z\n"
-            + "w0i0j1rau4T7Bi+thc/VZpCyuwt63mZWcRs5PlQzpL34bBSXL5L6G9XUtXn8pXwU\n"
-            + "GMhNDp5xVGbslRqTU8s=\n"
-            + "-----END PUBLIC KEY-----\n";
-        internal const string PrivateKey = "-----BEGIN EC PRIVATE KEY-----\n"
-            + "MIHcAgEBBEIAVItA/A9H8WA0rOmDO5kq774be6noZ73xWJkbmzihkhtnYJ+eCQl4\n"
-            + "G68ZFKildLuR2DElMBrNgJHY1TkL9hr7U9GgBwYFK4EEACOhgYkDgYYABAFUhWeC\n"
-            + "FTMeYIRncc2MOZpkwntTBl9q/ZJhwS1sNBzi4+GITBahhkzHOC+zPW9UaS6x9MiN\n"
-            + "xd4J8Nn7G72CtFi3iQGjf3PDSLSPWtq7hPsGL62Fz9VmkLK7C3reZlZxGzk+VDOk\n"
-            + "vfhsFJcvkvob1dS1efylfBQYyE0OnnFUZuyVGpNTyw==\n"
-            + "-----END EC PRIVATE KEY-----\n";
         internal const string Kid = "45fc75cf-5649-4134-84b3-192c2c78e990";
+        internal static string PrivateKey = File.ReadAllText(TestResourcePath("ec512-private.pem"));
+        internal static string PublicKey = File.ReadAllText(TestResourcePath("ec512-public.pem"));
 
         [Fact]
         public void SignAndVerify()
@@ -75,7 +63,7 @@ namespace Tests
             var body = "{\"currency\":\"GBP\",\"max_amount_in_minor\":5000000}";
             var idempotency_key = "idemp-2076717c-9005-4811-a321-9e0787fa0382";
             var path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
-            var tlSignature = "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2NDktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGVhZGVycyI6IklkZW1wb3RlbmN5LUtleSJ9..AfhpFccUCUKEmotnztM28SUYgMnzPNfDhbxXUSc-NByYc1g-rxMN6HS5g5ehiN5yOwb0WnXPXjTCuZIVqRvXIJ9WAPr0P9R68ro2rsHs5HG7IrSufePXvms75f6kfaeIfYKjQTuWAAfGPAeAQ52PNQSd5AZxkiFuCMDvsrnF5r0UQsGi";
+            var tlSignature = File.ReadAllText(TestResourcePath("tl-signature.txt")).Trim();
 
             Verifier.VerifyWithPem(PublicKey)
                 .Method("POST")
@@ -272,6 +260,31 @@ namespace Tests
         {
             var tlSignature = File.ReadAllText(TestResourcePath("webhook-signature.txt")).Trim();
             Verifier.ExtractJku(tlSignature).Should().Be("https://webhooks.truelayer.com/.well-known/jwks");
+        }
+
+        [Fact]
+        public void Verifier_Jwks()
+        {
+            var tlSignature = File.ReadAllText(TestResourcePath("webhook-signature.txt")).Trim();
+            var jwks = File.ReadAllText(TestResourcePath("jwks.json"));
+
+            Verifier.VerifyWithJwks(jwks)
+                .Method("POST")
+                .Path("/tl-webhook")
+                .Header("x-tl-webhook-timestamp", "2021-11-29T11:42:55Z")
+                .Header("content-type", "application/json")
+                .Body("{\"event_type\":\"example\",\"event_id\":\"18b2842b-a57b-4887-a0a6-d3c7c36f1020\"}")
+                .Verify(tlSignature); // should not throw
+
+            Action verify = () => Verifier.VerifyWithJwks(jwks)
+                .Method("POST")
+                .Path("/tl-webhook")
+                .Header("x-tl-webhook-timestamp", "2021-12-02T14:18:00Z") // different
+                .Header("content-type", "application/json")
+                .Body("{\"event_type\":\"example\",\"event_id\":\"18b2842b-a57b-4887-a0a6-d3c7c36f1020\"}")
+                .Verify(tlSignature);
+
+            verify.Should().Throw<SignatureException>();
         }
 
         /// <summary>Return working path to /test-resources/$subpath</summary>

--- a/csharp/test/truelayer-signing.test.csproj
+++ b/csharp/test/truelayer-signing.test.csproj
@@ -7,10 +7,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <ProjectReference Include="..\src\truelayer-signing.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds methods to allow extracting webhook signature `jku` and verify using the jwks response data directly.

See #23 for motivating details.

## Example
```cs
var jku = Verifier.ExtractJku(webhookSignature);
```
```cs
Verifier.VerifyWithJwks(jwks)
    .Method("POST")
    .Path("/tl-webhook")
    .Header("x-tl-webhook-timestamp", "2021-11-29T11:42:55Z")
    .Header("content-type", "application/json")
    .Body("{\"event_type\":\"example\",\"event_id\":\"18b2842b-a57b-4887-a0a6-d3c7c36f1020\"}")
    .Verify(webhookSignature); // throws SignatureException if invalid
```