### PR TITLE
Add pre-attached trailing dots test scenarios

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.4
+* Fix `Verifier` allowing non-detached jws signatures with trailing dots.
+
 ## 0.1.3
 * Add `Verifier.ExtractJku` to extract `jku` jws header from webhook signatures.
 * Add `Verifier.VerifyWithJwks` to aid verifying webhook signatures.

--- a/csharp/test/ErrorTest.cs
+++ b/csharp/test/ErrorTest.cs
@@ -58,6 +58,27 @@ namespace Tests
             verify.Should().Throw<SignatureException>();
         }
 
+        [Fact]
+        public void InvalidButPreAttachedJwsBodyTrailingDots()
+        {
+            // signature for `/bar` but with a valid jws-body pre-attached
+            // if we run verify on this unchanged it'll work!
+            const string Signature = "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2ND"
+                + "ktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGV"
+                + "hZGVycyI6IiJ9.UE9TVCAvYmFyCnt9.ARLa7Q5b8k5CIhfy1qrS-IkNqCDeE-VFRD"
+                + "z7Lb0fXUMOi_Ktck-R7BHDMXFDzbI5TyaxIo5TGHZV_cs0fg96dlSxAERp3UaN2oC"
+                + "QHIE5gQ4m5uU3ee69XfwwU_RpEIMFypycxwq1HOf4LzTLXqP_CDT8DdyX8oTwYdUB"
+                + "d2d3D17Wd9UA....";
+
+            Action verify = () => Verifier.VerifyWithPem(PublicKey)
+                .Method("post")
+                .Path("/foo") // not /bar so should fail
+                .Body("{}")
+                .Verify(Signature);
+
+            verify.Should().Throw<SignatureException>();
+        }
+
         [Theory]
         [InlineData("alg")]
         [InlineData("kid")]

--- a/go/tlsigning_test.go
+++ b/go/tlsigning_test.go
@@ -276,10 +276,29 @@ func TestEnforceDetached(t *testing.T) {
 	_, publicKeyBytes := getTestKeys(assert)
 
 	// signature for `/bar` but with a valid jws-body pre-attached
-	tlSignature := getTlSignature(assert)
+	tlSignature := "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2NDktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGVhZGVycyI6IiJ9.UE9TVCAvYmFyCnt9.ARLa7Q5b8k5CIhfy1qrS-IkNqCDeE-VFRDz7Lb0fXUMOi_Ktck-R7BHDMXFDzbI5TyaxIo5TGHZV_cs0fg96dlSxAERp3UaN2oCQHIE5gQ4m5uU3ee69XfwwU_RpEIMFypycxwq1HOf4LzTLXqP_CDT8DdyX8oTwYdUBd2d3D17Wd9UA"
 
 	body := []byte("{}")
 	path := "/foo"
+	err := VerifyWithPem(publicKeyBytes).
+		Method("post").
+		Path(path).
+		Body(body).
+		Verify(tlSignature)
+	assert.NotNilf(err, "signature verification should fail: %v", err)
+	assert.ErrorAs(&errors.JwsError{}, &err, "error should be a JwsError")
+}
+
+func TestEnforceDetachedTrailingDots(t *testing.T) {
+	assert := assert.New(t)
+
+	_, publicKeyBytes := getTestKeys(assert)
+
+	// signature for `/bar` but with a valid jws-body pre-attached
+	tlSignature := "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2NDktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGVhZGVycyI6IiJ9.UE9TVCAvYmFyCnt9.ARLa7Q5b8k5CIhfy1qrS-IkNqCDeE-VFRDz7Lb0fXUMOi_Ktck-R7BHDMXFDzbI5TyaxIo5TGHZV_cs0fg96dlSxAERp3UaN2oCQHIE5gQ4m5uU3ee69XfwwU_RpEIMFypycxwq1HOf4LzTLXqP_CDT8DdyX8oTwYdUBd2d3D17Wd9UA...."
+
+	body := []byte("{}")
+	path := "/bar"
 	err := VerifyWithPem(publicKeyBytes).
 		Method("post").
 		Path(path).

--- a/java/lib/build.gradle
+++ b/java/lib/build.gradle
@@ -15,6 +15,18 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 }
 
+test {
+    testLogging {
+        events "passed", "skipped", "failed" //, "standardOut", "standardError"
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
+
+        showStandardStreams = false
+    }
+}
+
 java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(8))

--- a/java/lib/src/test/java/truelayer/signing/UsageTest.java
+++ b/java/lib/src/test/java/truelayer/signing/UsageTest.java
@@ -306,7 +306,7 @@ public class UsageTest {
 
         SignatureException invalidSignatureException = assertThrows(SignatureException.class, () -> verifier.verify(signature));
 
-        assertEquals("The payload Base64URL part must be empty", invalidSignatureException.getMessage());
+        assertEquals("Invalid serialized unsecured/JWS/JWE object: Too many part delimiters", invalidSignatureException.getMessage());
     }
 
     @Test

--- a/java/lib/src/test/java/truelayer/signing/UsageTest.java
+++ b/java/lib/src/test/java/truelayer/signing/UsageTest.java
@@ -289,6 +289,27 @@ public class UsageTest {
     }
 
     @Test
+    public void invalidButPreAttachedBodyTrailingDots() throws IOException {
+        byte[] publicKey = readAllBytes(new File("src/test/resources/ec512-public.pem").toPath());
+
+        String signature = "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2ND"
+                + "ktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGV"
+                + "hZGVycyI6IiJ9.UE9TVCAvYmFyCnt9.ARLa7Q5b8k5CIhfy1qrS-IkNqCDeE-VFRD"
+                + "z7Lb0fXUMOi_Ktck-R7BHDMXFDzbI5TyaxIo5TGHZV_cs0fg96dlSxAERp3UaN2oC"
+                + "QHIE5gQ4m5uU3ee69XfwwU_RpEIMFypycxwq1HOf4LzTLXqP_CDT8DdyX8oTwYdUB"
+                + "d2d3D17Wd9UA....";
+
+        Verifier verifier = Verifier.from(publicKey)
+                .method("post")
+                .path("/foo")
+                .body("{}".getBytes());
+
+        SignatureException invalidSignatureException = assertThrows(SignatureException.class, () -> verifier.verify(signature));
+
+        assertEquals("The payload Base64URL part must be empty", invalidSignatureException.getMessage());
+    }
+
+    @Test
     public void signAndVerifyNoHeaders() throws IOException {
         byte[] privateKey = readAllBytes(new File("src/test/resources/ec512-private.pem").toPath());
         byte[] publicKey = readAllBytes(new File("src/test/resources/ec512-public.pem").toPath());

--- a/nodejs/src/__tests__/usage.test.ts
+++ b/nodejs/src/__tests__/usage.test.ts
@@ -76,7 +76,7 @@ describe('verify', () => {
       method: "post",
       path,
       body,
-    }as any);
+    } as any);
 
     verify({
       publicKeyPem: PUBLIC_KEY,
@@ -99,6 +99,26 @@ describe('verify', () => {
       + "z7Lb0fXUMOi_Ktck-R7BHDMXFDzbI5TyaxIo5TGHZV_cs0fg96dlSxAERp3UaN2oC"
       + "QHIE5gQ4m5uU3ee69XfwwU_RpEIMFypycxwq1HOf4LzTLXqP_CDT8DdyX8oTwYdUB"
       + "d2d3D17Wd9UA";
+
+    const fn = () => verify({
+      publicKeyPem: PUBLIC_KEY,
+      signature,
+      method: "post",
+      path: "/foo", // not /bar so should fail
+      body: "{}"
+    } as any);
+    expect(fn).toThrow(new SignatureError("Invalid signature"));
+  });
+
+  it('should throw using a mismatched signature that has an attached valid body with trailing dots', () => {
+    // signature for `/bar` but with a valid jws-body pre-attached
+    // if we run a simple jws verify on this unchanged it'll work!
+    const signature = "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2ND"
+      + "ktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGV"
+      + "hZGVycyI6IiJ9.UE9TVCAvYmFyCnt9.ARLa7Q5b8k5CIhfy1qrS-IkNqCDeE-VFRD"
+      + "z7Lb0fXUMOi_Ktck-R7BHDMXFDzbI5TyaxIo5TGHZV_cs0fg96dlSxAERp3UaN2oC"
+      + "QHIE5gQ4m5uU3ee69XfwwU_RpEIMFypycxwq1HOf4LzTLXqP_CDT8DdyX8oTwYdUB"
+      + "d2d3D17Wd9UA....";
 
     const fn = () => verify({
       publicKeyPem: PUBLIC_KEY,
@@ -240,7 +260,7 @@ describe('verify', () => {
       body,
     } as any);
 
-    const fn  = () => verify({
+    const fn = () => verify({
       publicKeyPem: PUBLIC_KEY,
       signature,
       method: "post",

--- a/rust/tests/usage.rs
+++ b/rust/tests/usage.rs
@@ -125,6 +125,25 @@ fn mismatched_signature_with_attached_valid_body() {
 }
 
 #[test]
+fn mismatched_signature_with_attached_valid_body_trailing_dots() {
+    // signature for `/bar` but with a valid jws-body pre-attached
+    // if we run a simple jws verify on this unchanged it'll work!
+    let tl_signature = "eyJhbGciOiJFUzUxMiIsImtpZCI6IjQ1ZmM3NWNmLTU2ND\
+      ktNDEzNC04NGIzLTE5MmMyYzc4ZTk5MCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGV\
+      hZGVycyI6IiJ9.UE9TVCAvYmFyCnt9.ARLa7Q5b8k5CIhfy1qrS-IkNqCDeE-VFRD\
+      z7Lb0fXUMOi_Ktck-R7BHDMXFDzbI5TyaxIo5TGHZV_cs0fg96dlSxAERp3UaN2oC\
+      QHIE5gQ4m5uU3ee69XfwwU_RpEIMFypycxwq1HOf4LzTLXqP_CDT8DdyX8oTwYdUB\
+      d2d3D17Wd9UA....";
+
+    truelayer_signing::verify_with_pem(PUBLIC_KEY)
+        .method("POST")
+        .path("/foo") // not bar so should fail
+        .body("{}".as_bytes())
+        .verify(tl_signature)
+        .expect_err("verify should fail");
+}
+
+#[test]
 fn verify_full_request_static_signature() {
     let body = br#"{"currency":"GBP","max_amount_in_minor":5000000}"#;
     let idempotency_key = b"idemp-2076717c-9005-4811-a321-9e0787fa0382";


### PR DESCRIPTION
JWE tokens may have trailing dots, which can potentially cause issue with some `replace("..")` logic with pre-attached bodies.