### PR TITLE
Add verifying webhooks readme examples

### DIFF
--- a/csharp/README.md
+++ b/csharp/README.md
@@ -14,3 +14,23 @@ var tlSignature = Signer.SignWithPem(kid, privateKey)
     .Body(body)
     .Sign();
 ```
+
+## Verifying webhooks
+The `VerifyWithJwks` function may be used to verify webhook `Tl-Signature` header signatures.
+ 
+```csharp
+// `jku` field is included in webhook signatures
+var jku = Verifier.ExtractJku(webhookSignature);
+
+// fetch jwks JSON from the `jku` url (not provided by this lib)
+var jwks = fetchJwks(jku);
+
+// jwks may be used directly to verify a signature
+// a SignatureException is thrown is verification fails
+Verifier.VerifyWithJwks(jwks)
+    .Method("POST")
+    .Path(path)
+    .Headers(headers)
+    .Body(body)
+    .Verify(webhookSignature);
+```

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -43,10 +43,11 @@ The `verify` function may be used to verify webhook `Tl-Signature` header signat
 ```javascript
 const tlSigning = require('truelayer-signing');
 
+// `jku` field is included in webhook signatures
 let jku = tlSigning.extractJku(webhookSignature);
 
-// fetch jwks JSON from the `jku` url.
-let jwks = fetch_jwks(jku);
+// fetch jwks JSON from the `jku` url (not provided by this lib)
+let jwks = fetchJwks(jku);
 
 // jwks may be used directly to verify a signature
 // a SignatureError is thrown is verification fails

--- a/rust/README.md
+++ b/rust/README.md
@@ -16,3 +16,22 @@ let tl_signature = truelayer_signing::sign_with_pem(kid, private_key)
 
 ## Prerequisites
 - OpenSSL (see [here](https://www.openssl.org/) for instructions).
+
+## Verifying webhooks
+The `verify_with_jwks` function may be used to verify webhook `Tl-Signature` header signatures.
+ 
+```rust
+// `jku` field is included in webhook signatures
+let jku = truelayer_signing::extract_jws_header(webhook_signature)?.jku?;
+
+// fetch jwks JSON from the `jku` url (not provided by this lib)
+let jwks = fetch_jwks(jku);
+
+// jwks may be used directly to verify a signature
+truelayer_signing::verify_with_jwks(jwks)
+    .method("POST")
+    .path(path)
+    .headers(headers)
+    .body(body)
+    .verify(webhook_signature)?;
+```


### PR DESCRIPTION
Adds rust & C# verify webhook snippet examples to their READMEs. Also update the nodejs one.