### PR TITLE
Support jwk.alg being "ES512"

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.5
+* Add support for verifying jwks with alg: `ES512`.
+
 ## 0.1.4
 * Fix `Verifier` allowing non-detached jws signatures with trailing dots.
 

--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -231,7 +231,6 @@ namespace TrueLayer.Signing
             var jwk = SignatureException.Try(() => jwks.Keys.First(key => key.Kid == kid), "no jwk found with kid");
 
             SignatureException.Ensure(jwk.Kty == "EC", "unsupported jwk.kty");
-            SignatureException.Ensure(jwk.Alg == "EC", "unsupported jwk.alg");
             SignatureException.Ensure(jwk.Crv == "P-521", "unsupported jwk.crv");
 
             SignatureException.TryAction(() => key.ImportParameters(new ECParameters

--- a/csharp/src/truelayer-signing.csproj
+++ b/csharp/src/truelayer-signing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageVersion>0.1.4</PackageVersion>
+    <PackageVersion>0.1.5</PackageVersion>
     <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Nullable>enable</Nullable>

--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-* Added verifying webhooks readme examples
+## 0.1.3
+* Add support for verifying jwks with alg: `ES512`.
+* Added verifying webhooks readme examples.
 
 ## 0.1.2
 * Added `VerifyWithJwks` method to aid verifying webhook signatures.

--- a/go/crypto/crypto.go
+++ b/go/crypto/crypto.go
@@ -136,9 +136,6 @@ func (jwk jwk) parseP521() (*ecdsa.PublicKey, error) {
 	if jwk.Kty != "EC" {
 		return nil, fmt.Errorf("unsupported jwk kty")
 	}
-	if jwk.Alg != "EC" {
-		return nil, fmt.Errorf("unsupported jwk alg")
-	}
 	if jwk.Crv != "P-521" {
 		return nil, fmt.Errorf("unsupported jwk crv")
 	}

--- a/java/CHANGELOG.md
+++ b/java/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2
+* Add support for verifying jwks with alg: `ES512`.
+
 ## 0.1.1
 * Add `Verifier.extractJku` to extract `jku` jws header from webhook signatures.
 * Add `Verifier.verifyWithJwks` to aid verifying webhook signatures.

--- a/java/lib/src/main/java/truelayer/signing/VerifierFromJwks.java
+++ b/java/lib/src/main/java/truelayer/signing/VerifierFromJwks.java
@@ -46,7 +46,6 @@ class VerifierFromJwks extends Verifier {
         return SignatureException.evaluate(() -> {
             ECKey ecKey = keyByKeyId.toECKey();
             SignatureException.ensure(ecKey.getKeyType().getValue().equals("EC"), "unsupported jwk.kty");
-            SignatureException.ensure(ecKey.getAlgorithm().getName().equals("EC"), "unsupported jwk.alg");
             SignatureException.ensure(ecKey.getCurve().equals(Curve.P_521), "unsupported jwk.crv");
 
             return ecKey.toECPublicKey();

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.3
+* Add support for verifying jwks with alg: `ES512`.
+
 ## 0.1.2
 * Add `verify_with_jwks` method to aid verifying webhook signatures.
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truelayer-signing"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Alex Butler <alex.butler@truelayer.com>"]
 edition = "2018"
 description = "Produce & verify TrueLayer API requests signatures"

--- a/rust/src/openssl.rs
+++ b/rust/src/openssl.rs
@@ -94,8 +94,6 @@ struct Jwk {
     #[serde(default)]
     kty: String,
     #[serde(default)]
-    alg: String,
-    #[serde(default)]
     crv: String,
     #[serde(default)]
     x: String,
@@ -106,7 +104,6 @@ struct Jwk {
 impl Jwk {
     fn parse_p521(self) -> anyhow::Result<EcKey<Public>> {
         ensure!(self.kty == "EC", "unsupported jwk kty");
-        ensure!(self.alg == "EC", "unsupported jwk alg");
         ensure!(self.crv == "P-521", "unsupported jwk crv");
 
         let x = base64::decode_config(self.x, base64::URL_SAFE_NO_PAD)?;

--- a/test-resources/jwks.json
+++ b/test-resources/jwks.json
@@ -9,7 +9,7 @@
     },
     {
       "kty": "EC",
-      "alg": "EC",
+      "alg": "ES512",
       "kid": "45fc75cf-5649-4134-84b3-192c2c78e990",
       "crv": "P-521",
       "x": "AVSFZ4IVMx5ghGdxzYw5mmTCe1MGX2r9kmHBLWw0HOLj4YhMFqGGTMc4L7M9b1RpLrH0yI3F3gnw2fsbvYK0WLeJ",


### PR DESCRIPTION
Referring to https://datatracker.ietf.org/doc/html/draft-ietf-jose-json-web-algorithms#section-3.1 our EC jwk.alg field should actually be `ES512` rather than `EC`.

This pr adds support for that without breaking the existing alg value, since this field isn't strictly required anyway.

Affects langs: **rust, go, java, csharp**