### PR TITLE
Update node,c#,rust verify webhook snippets

### DIFF
--- a/csharp/README.md
+++ b/csharp/README.md
@@ -30,7 +30,7 @@ var jwks = fetchJwks(jku);
 Verifier.VerifyWithJwks(jwks)
     .Method("POST")
     .Path(path)
-    .Headers(headers)
+    .Headers(allWebhookHeaders)
     .Body(body)
     .Verify(webhookSignature);
 ```

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -57,6 +57,6 @@ tlSigning.verify({
   method: "post",
   path,
   body,
-  headers,
+  headers: allWebhookHeaders,
 });
 ```

--- a/rust/README.md
+++ b/rust/README.md
@@ -31,7 +31,7 @@ let jwks = fetch_jwks(jku);
 truelayer_signing::verify_with_jwks(jwks)
     .method("POST")
     .path(path)
-    .headers(headers)
+    .headers(all_webhook_headers)
     .body(body)
     .verify(webhook_signature)?;
 ```


### PR DESCRIPTION
Update the examples to hint that webhook verification should add all headers to the verifier.