### PR TITLE
Move under com.truelayer and define release pipeline

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -2,26 +2,98 @@ name: Java
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
 
 jobs:
-  test:
-    name: Test
+  build-and-test:
+    name: Build and Test
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 8, 11, 17 ]
+        java: [ 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
           cache: gradle
+      - name: Validate gradle wrapper
+        uses: gradle/wrapper-validation-action@v1.0.4
       - name: Test
         run: cd java && ./gradlew test
+
+  set-release-version:
+    name: Prepare version to tag and release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2 #we need to make a git diff of the last 2 commits
+      - name: Get project version
+        id: get_project_version
+        run: |
+          cd java && PROJECT_VERSION=$(./gradlew properties | grep "version:" | awk '{print $2}')
+          echo "::set-output name=project_version::$PROJECT_VERSION"
+      - name: Get changed version from last two commits
+        id: get_changed_version
+        run: |
+          CHANGED_VERSION=$(git diff HEAD^ -- ./java/gradle.properties | grep +version= | awk -F "=" '{print $2}')
+          echo "::set-output name=changed_version::$CHANGED_VERSION"
+      - name: Print changed version from last two commits
+        run: echo ${{ steps.get_changed_version.outputs.changed_version }}
+    outputs:
+      project_version: ${{ steps.get_project_version.outputs.project_version }}
+      changed_version: ${{ steps.get_changed_version.outputs.changed_version }}
+
+  publish:
+    name: Publish to Sonatype and Maven Central
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && needs.set-release-version.outputs.changed_version != ''
+    needs: [build-and-test, set-release-version]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          cache: gradle
+      - name: Validate gradle wrapper
+        uses: gradle/wrapper-validation-action@v1.0.4
+      - name: Publish to Sonatype and Maven Central
+        # run: cd java && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: cd java && ./gradlew publishToSonatype closeSonatypeStagingRepository #manual release from Nexus UI for now
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          SONATYPE_GPG_PASSPHRASE: ${{ secrets.SONATYPE_GPG_PASSPHRASE }}
+
+  create_github_release:
+    name: Create Github Release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && !contains(needs.set-release-version.outputs.project_version, 'SNAPSHOT')
+    needs: [publish]
+    steps:
+      - name: Create tag
+        id: create_tag
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ needs.set-release-version.outputs.project_version }}
+          tag_prefix: 'java-v'
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.create_tag.outputs.new_tag }}
+          generate_release_notes: false

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    //    // nexus publishing
+    id "io.github.gradle-nexus.publish-plugin"  version "1.1.0"
+
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl = uri(sonatype_repository_url)
+            snapshotRepositoryUrl = uri(sonatype_snapshot_repository_url)
+            username = System.getenv("SONATYPE_USERNAME")
+            password = System.getenv("SONATYPE_PASSWORD")
+        }
+    }
+}

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -1,0 +1,16 @@
+# Main properties
+group=com.truelayer
+version=0.2.0-SNAPSHOT
+
+sonatype_repository_url=https://s01.oss.sonatype.org/service/local/
+sonatype_snapshot_repository_url=https://s01.oss.sonatype.org/content/repositories/snapshots/
+
+# Artifacts properties
+artifact_id=truelayer-signing
+project_name=TrueLayer Signing
+project_description=TrueLayer Java Signing library
+project_url=https://github.com/TrueLayer/truelayer-signing
+project_license_url=https://raw.githubusercontent.com/TrueLayer/truelayer-signing/main/LICENSE-MIT
+project_license_name=MIT License
+project_developer=truelayer
+project_scm=scm:git:https://github.com/TrueLayer/truelayer-signing.git˜

--- a/java/lib/build.gradle
+++ b/java/lib/build.gradle
@@ -1,49 +1,23 @@
 plugins {
-    // Apply the java-library plugin for API and implementation separation.
     id 'java-library'
     id 'maven-publish'
+    id 'signing'
 }
 
 repositories {
-    // Use Maven Central for resolving dependencies.
     mavenCentral()
-}
-
-dependencies {
-    implementation("org.bouncycastle:bcpkix-jdk15on:1.69")
-    implementation("com.nimbusds:nimbus-jose-jwt:9.15.2")
-    testImplementation 'junit:junit:4.13.2'
-}
-
-test {
-    testLogging {
-        events "passed", "skipped", "failed" //, "standardOut", "standardError"
-        showExceptions true
-        exceptionFormat "full"
-        showCauses true
-        showStackTraces true
-
-        showStandardStreams = false
-    }
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
-    }
-    withJavadocJar()
-    withSourcesJar()
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            groupId "com.truelayer"
-            artifactId "truelayer-signing"
-            version = "0.1.0"
-            from components.java
-        }
+        languageVersion = JavaLanguageVersion.of(8)
     }
 }
 
+apply from: project.file('test.gradle')
+apply from: project.file('publish.gradle')
 
+dependencies {
+    implementation("org.bouncycastle:bcpkix-jdk15on:1.69")
+    implementation("com.nimbusds:nimbus-jose-jwt:9.15.2")
+}

--- a/java/lib/publish.gradle
+++ b/java/lib/publish.gradle
@@ -1,0 +1,48 @@
+// Package javadoc and sources
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+// Configure publishing repositories and publications
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from(components.java)
+
+            pom {
+                name = rootProject.project_name
+                artifactId = rootProject.artifact_id
+                packaging = 'jar'
+                description = rootProject.project_description
+                url = rootProject.project_url
+                scm {
+                    connection = rootProject.project_scm
+                    developerConnection = rootProject.project_scm
+                    url = rootProject.project_url
+                }
+                licenses {
+                    license {
+                        name = rootProject.project_license_name
+                        url = rootProject.project_license_url
+                    }
+                }
+                developers {
+                    developer {
+                        id = rootProject.project_developer
+                        name = rootProject.project_developer
+                    }
+                }
+            }
+        }
+    }
+}
+
+ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
+signing {
+    def signingKey = System.getenv('SONATYPE_GPG_KEY')
+    def signingPassword = System.getenv('SONATYPE_GPG_PASSPHRASE')
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications.mavenJava
+    required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
+}

--- a/java/lib/src/main/java/com/truelayer/signing/CheckedSupplier.java
+++ b/java/lib/src/main/java/com/truelayer/signing/CheckedSupplier.java
@@ -1,4 +1,4 @@
-package truelayer.signing;
+package com.truelayer.signing;
 
 @FunctionalInterface
 public interface CheckedSupplier<T> {

--- a/java/lib/src/main/java/com/truelayer/signing/HeaderName.java
+++ b/java/lib/src/main/java/com/truelayer/signing/HeaderName.java
@@ -1,4 +1,4 @@
-package truelayer.signing;
+package com.truelayer.signing;
 
 /**
  * Case-insensitive string header name comparison.

--- a/java/lib/src/main/java/com/truelayer/signing/KeyException.java
+++ b/java/lib/src/main/java/com/truelayer/signing/KeyException.java
@@ -1,4 +1,4 @@
-package truelayer.signing;
+package com.truelayer.signing;
 
 /**
  * Key error

--- a/java/lib/src/main/java/com/truelayer/signing/SignatureException.java
+++ b/java/lib/src/main/java/com/truelayer/signing/SignatureException.java
@@ -1,4 +1,4 @@
-package truelayer.signing;
+package com.truelayer.signing;
 
 /**
  * Sign/verification error

--- a/java/lib/src/main/java/com/truelayer/signing/Signer.java
+++ b/java/lib/src/main/java/com/truelayer/signing/Signer.java
@@ -1,4 +1,4 @@
-package truelayer.signing;
+package com.truelayer.signing;
 
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSObject;
@@ -11,7 +11,7 @@ import java.security.interfaces.ECPrivateKey;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static truelayer.signing.Utils.jwsHeaderMap;
+import static com.truelayer.signing.Utils.jwsHeaderMap;
 
 /**
  * Builder to generate a Tl-Signature header value using a private key.

--- a/java/lib/src/main/java/com/truelayer/signing/Utils.java
+++ b/java/lib/src/main/java/com/truelayer/signing/Utils.java
@@ -1,4 +1,4 @@
-package truelayer.signing;
+package com.truelayer.signing;
 
 import com.nimbusds.jose.util.Base64URL;
 

--- a/java/lib/src/main/java/com/truelayer/signing/Verifier.java
+++ b/java/lib/src/main/java/com/truelayer/signing/Verifier.java
@@ -1,4 +1,4 @@
-package truelayer.signing;
+package com.truelayer.signing;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;

--- a/java/lib/src/main/java/com/truelayer/signing/VerifierFromJwks.java
+++ b/java/lib/src/main/java/com/truelayer/signing/VerifierFromJwks.java
@@ -1,4 +1,4 @@
-package truelayer.signing;
+package com.truelayer.signing;
 
 import com.nimbusds.jose.JOSEObject;
 import com.nimbusds.jose.JWSHeader;

--- a/java/lib/src/main/java/com/truelayer/signing/VerifierFromPublicKey.java
+++ b/java/lib/src/main/java/com/truelayer/signing/VerifierFromPublicKey.java
@@ -1,4 +1,4 @@
-package truelayer.signing;
+package com.truelayer.signing;
 
 import com.nimbusds.jose.*;
 import com.nimbusds.jose.crypto.ECDSAVerifier;

--- a/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
+++ b/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
@@ -1,5 +1,8 @@
-package truelayer.signing;
+package com.truelayer.signing;
 
+import com.truelayer.signing.SignatureException;
+import com.truelayer.signing.Signer;
+import com.truelayer.signing.Verifier;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -39,9 +42,7 @@ public class UsageTest {
         String path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
 
         String tlSignature = Signer.from(kid, privateKey)
-                .headers(new HashMap<String, String>() {{
-                    put("Idempotency-Key", idempotencyKey);
-                }})
+                .header("Idempotency-Key", idempotencyKey)
                 .method("post")
                 .path(path)
                 .body(body)

--- a/java/lib/test.gradle
+++ b/java/lib/test.gradle
@@ -1,0 +1,17 @@
+tasks.named('test') {
+    testLogging {
+        events "passed", "skipped", "failed" //, "standardOut", "standardError"
+        showExceptions true
+        exceptionFormat "full"
+        showCauses true
+        showStackTraces true
+
+        showStandardStreams = false
+    }
+}
+
+// Configure test dependencies
+dependencies {
+    // JUnit test framework.
+    testImplementation 'junit:junit:4.13.2'
+}

--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'truelayer-signing'
+rootProject.name = "truelayer-signing"
 include 'lib'

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,0 @@
-install:
-  - echo "publish trulayer-signing"
-  - cd java
-  - ./gradlew clean build publishToMavenLocal


### PR DESCRIPTION
This PR adds:
- Release workflow. Push to maven central only if the `gradle.properties` version attribute changed from the previous commit. It will just close the staging repository at first, so promotion will be manual.
- Move package `truelayer.signing` to `com.truelayer.signing`

When merged it will not trigger a release.
I will do another PR with Changelog changes and version set to `0.2.0`.

