### PR TITLE
Add C# webhook server example

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -18,3 +18,12 @@ jobs:
       with:
         dotnet-version: '3.1.x'
     - run: cd csharp && dotnet build && dotnet test
+
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+    - run: cd csharp/examples/webhook-server && dotnet build

--- a/csharp/.gitignore
+++ b/csharp/.gitignore
@@ -1,5 +1,7 @@
 obj
 bin
+examples/**/obj
+examples/**/bin
 NuGet.Config
 .DS_Store
 

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -35,3 +35,5 @@ Verifier.VerifyWithJwks(jwks)
     .Body(body)
     .Verify(webhookSignature);
 ```
+
+See [webhook server example](./examples/webhook-server/).

--- a/csharp/examples/webhook-server/ExampleWebhookServer.csproj
+++ b/csharp/examples/webhook-server/ExampleWebhookServer.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>9</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\truelayer-signing.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/examples/webhook-server/Program.cs
+++ b/csharp/examples/webhook-server/Program.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace TrueLayer.ExampleWebhookServer
+{
+    public class Program
+    {
+        public static void Main(string[] args) => CreateHostBuilder(args).Build().Run();
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
+    }
+}

--- a/csharp/examples/webhook-server/README.md
+++ b/csharp/examples/webhook-server/README.md
@@ -1,0 +1,19 @@
+# C# webhook server example
+A http server than can receive and verify signed TrueLayer webhooks.
+
+## Run
+Run the server.
+```sh
+dotnet run
+```
+
+Send a valid webhook that was signed for path `/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b`.
+```sh
+curl -iX POST -H "Content-Type: application/json" \
+    -H "X-Tl-Webhook-Timestamp: 2022-03-11T14:00:33Z" \
+    -H "Tl-Signature: eyJhbGciOiJFUzUxMiIsImtpZCI6IjFmYzBlNTlmLWIzMzUtNDdjYS05OWE5LTczNzQ5NTc1NmE1OCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGVhZGVycyI6IngtdGwtd2ViaG9vay10aW1lc3RhbXAiLCJqa3UiOiJodHRwczovL3dlYmhvb2tzLnRydWVsYXllci5jb20vLndlbGwta25vd24vandrcyJ9..AE_QsBRhnsMkcRzd42wvY1e2HruUhkOgjuZKktGH_WmbD7rBzoaEHUuF36IxyyvCbLajd3MBExNmzjbrOQsGaspwAI5DcGVMFLKUhB7ZzUlTP9up3eNUrdwWyyfBWDQb-qmEuLnrhFDJvgCXEqlV5OLrt-O7LaRAJ4f9KHsZLQ_j2vPC" \
+    -d "{\"event_type\":\"payout_settled\",\"event_schema_version\":1,\"event_id\":\"8fb9fb4e-bb2b-400b-af64-59e5dde74bad\",\"event_body\":{\"transaction_id\":\"c34c8721-66a9-49f6-a229-284efcf88a02\",\"settled_at\":\"2022-03-11T14:00:32.933000Z\"}}" \
+    http://localhost:5000/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b
+```
+
+Modifying the `X-Tl-Webhook-Timestamp` header, the body or the path will cause the above signature to be invalid.

--- a/csharp/examples/webhook-server/Startup.cs
+++ b/csharp/examples/webhook-server/Startup.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TrueLayer.ExampleWebhookServer
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration) => Configuration = configuration;
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddHttpClient().AddControllers();
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseRouting().UseEndpoints(endpoints => endpoints.MapControllers());
+        }
+    }
+}

--- a/csharp/examples/webhook-server/WebhookController.cs
+++ b/csharp/examples/webhook-server/WebhookController.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using TrueLayer.Signing;
+
+namespace TrueLayer.ExampleWebhookServer
+{
+    [ApiController]
+    public sealed class WebhookController : ControllerBase
+    {
+        private readonly HttpClient _http;
+
+        public WebhookController(HttpClient httpClient) => _http = httpClient;
+
+        [HttpPost("/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b")]
+        public async Task<StatusCodeResult> PostHook()
+        {
+            try
+            {
+                await VerifyRequest();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"WARNING: Verification failed: {ex.Message ?? ex.GetType().Name}");
+                return StatusCode(401);
+            }
+
+            // handle verified webhook
+            return StatusCode(202);
+        }
+
+        async Task VerifyRequest()
+        {
+            // extract jku from signature
+            HttpContext.Request.Headers.TryGetValue("Tl-Signature", out var tlSignature);
+            if (!tlSignature.Any()) throw new InvalidOperationException("Missing Tl-Signature header");
+
+            var jku = Verifier.ExtractJku(tlSignature);
+
+            // ensure jku is an expected TrueLayer url
+            if (jku != "https://webhooks.truelayer.com/.well-known/jwks"
+                && jku != "https://webhooks.truelayer-sandbox.com/.well-known/jwks")
+            {
+                throw new InvalidOperationException($"unpermitted jku `{jku}`");
+            }
+
+            // fetch jwks (should cache this according to headers)
+            var jwksResponse = await _http.GetAsync(jku);
+            jwksResponse.EnsureSuccessStatusCode();
+            var jwks = await jwksResponse.Content.ReadAsByteArrayAsync();
+
+            // verify request
+            var allHeaders = HttpContext.Request.Headers.Select(h => KeyValuePair.Create(h.Key, h.Value.First()));
+            var body = await new System.IO.StreamReader(HttpContext.Request.Body).ReadToEndAsync();
+
+            Verifier.VerifyWithJwks(jwks)
+                .Method("POST")
+                .Path(HttpContext.Request.Path)
+                .Headers(allHeaders)
+                .Body(body)
+                .Verify(tlSignature);
+        }
+    }
+}

--- a/csharp/examples/webhook-server/WebhookController.cs
+++ b/csharp/examples/webhook-server/WebhookController.cs
@@ -15,6 +15,8 @@ namespace TrueLayer.ExampleWebhookServer
 
         public WebhookController(HttpClient httpClient) => _http = httpClient;
 
+        // Note: Webhook path can be whatever is configured, here a unique path 
+        // is used matching the README example signature.
         [HttpPost("/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b")]
         public async Task<StatusCodeResult> PostHook()
         {


### PR DESCRIPTION
#47 for C#

# C# webhook server example
A http server than can receive and verify signed TrueLayer webhooks.

## Run
Run the server.
```sh
dotnet run
```

Send a valid webhook that was signed for path `/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b`.
```sh
curl -iX POST -H "Content-Type: application/json" \
    -H "X-Tl-Webhook-Timestamp: 2022-03-11T14:00:33Z" \
    -H "Tl-Signature: eyJhbGciOiJFUzUxMiIsImtpZCI6IjFmYzBlNTlmLWIzMzUtNDdjYS05OWE5LTczNzQ5NTc1NmE1OCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGVhZGVycyI6IngtdGwtd2ViaG9vay10aW1lc3RhbXAiLCJqa3UiOiJodHRwczovL3dlYmhvb2tzLnRydWVsYXllci5jb20vLndlbGwta25vd24vandrcyJ9..AE_QsBRhnsMkcRzd42wvY1e2HruUhkOgjuZKktGH_WmbD7rBzoaEHUuF36IxyyvCbLajd3MBExNmzjbrOQsGaspwAI5DcGVMFLKUhB7ZzUlTP9up3eNUrdwWyyfBWDQb-qmEuLnrhFDJvgCXEqlV5OLrt-O7LaRAJ4f9KHsZLQ_j2vPC" \
    -d "{\"event_type\":\"payout_settled\",\"event_schema_version\":1,\"event_id\":\"8fb9fb4e-bb2b-400b-af64-59e5dde74bad\",\"event_body\":{\"transaction_id\":\"c34c8721-66a9-49f6-a229-284efcf88a02\",\"settled_at\":\"2022-03-11T14:00:32.933000Z\"}}" \
    http://localhost:5000/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b
```

Modifying the `X-Tl-Webhook-Timestamp` header, the body or the path will cause the above signature to be invalid.
