### PR TITLE
Hint jku allowlist in webhook snippets + mention webhook verification in top-level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ They can then be verified using the associated public key.
 See [request-signing-v2.md](./request-signing-v2.md) for an explanation of how request signing is implemented.
 
 ## Webhook signature verification
-TrueLayer webhooks include a `Tl-Signature` similarl to request signatures. 
+TrueLayer webhooks include a `Tl-Signature` header similar to request signatures but signed by a TrueLayer private key.
 See per-language examples on how to properly verify webhooks.
 
 #### License

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ They can then be verified using the associated public key.
 ## Request signing specification
 See [request-signing-v2.md](./request-signing-v2.md) for an explanation of how request signing is implemented.
 
+## Webhook signature verification
+TrueLayer webhooks include a `Tl-Signature` similarl to request signatures. 
+See per-language examples on how to properly verify webhooks.
+
 #### License
 <sup>
 Licensed under either of <a href="LICENSE-APACHE">Apache License, Version

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -22,8 +22,9 @@ The `VerifyWithJwks` function may be used to verify webhook `Tl-Signature` heade
 // `jku` field is included in webhook signatures
 var jku = Verifier.ExtractJku(webhookSignature);
 
-// fetch jwks JSON from the `jku` url (not provided by this lib)
-var jwks = fetchJwks(jku);
+// check `jku` is an allowed TrueLayer url & fetch jwks JSON (not provided by this lib)
+EnsureJkuAllowed(jku);
+var jwks = FetchJwks(jku);
 
 // jwks may be used directly to verify a signature
 // a SignatureException is thrown is verification fails

--- a/go/README.md
+++ b/go/README.md
@@ -21,7 +21,10 @@ if err != nil {
   // Handle error
 }
 
-// fetch jwks JSON from the `jku` url (not provided by this lib)
+// check `jku` is an allowed TrueLayer url & fetch jwks JSON (not provided by this lib)
+if !jkuAllowed(jwsHeader.Jku) {
+  // Handle error
+}
 jwks := fetchJwks(jwsHeader.Jku)
 
 // jwks may be used directly to verify a signature

--- a/java/README.md
+++ b/java/README.md
@@ -40,8 +40,9 @@ The `Verifier.verifyWithJwks` function may be used to verify `Tl-Signature` head
 // `jku` field is included in webhook signatures
 String jku = Verifier.extractJku(webhookSignature);
 
-// fetch jwks JSON from the `jku` url (not provided by this lib)
-String jwks = fetchJwks(jku):
+// check `jku` is an allowed TrueLayer url & fetch jwks JSON (not provided by this lib)
+ensureJkuAllowed(jku);
+String jwks = fetchJwks(jku);
 
 Verifier.verifyWithJwks(jwks)
         .method("POST")

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -46,7 +46,8 @@ const tlSigning = require('truelayer-signing');
 // `jku` field is included in webhook signatures
 let jku = tlSigning.extractJku(webhookSignature);
 
-// fetch jwks JSON from the `jku` url (not provided by this lib)
+// check `jku` is an allowed TrueLayer url & fetch jwks JSON (not provided by this lib)
+ensureJkuAllowed(jku);
 let jwks = fetchJwks(jku);
 
 // jwks may be used directly to verify a signature

--- a/rust/README.md
+++ b/rust/README.md
@@ -24,7 +24,8 @@ The `verify_with_jwks` function may be used to verify webhook `Tl-Signature` hea
 // `jku` field is included in webhook signatures
 let jku = truelayer_signing::extract_jws_header(webhook_signature)?.jku?;
 
-// fetch jwks JSON from the `jku` url (not provided by this lib)
+// check `jku` is an allowed TrueLayer url & fetch jwks JSON (not provided by this lib)
+ensure_jku_allowed(jku)?;
 let jwks = fetch_jwks(jku);
 
 // jwks may be used directly to verify a signature


### PR DESCRIPTION
An important part of verifying a webhook signature is checking that the `jku` is an expected TrueLayer url. So we should hint at that in README snippets as well as include it in full examples like #47 

You could argue that it was already part of the not-included-here `fetchJwks(jku)` impl, but I think it's important enough that we should drive the point home by explicitly mentioning it.