### PR TITLE
Add Rust webhook server example

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,10 @@ jobs:
     - run: rustup update stable
     - uses: actions/checkout@v2
     - run: cd rust && cargo fmt -- --check
+
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+    - run: rustup update stable
+    - uses: actions/checkout@v2
+    - run: cd rust/examples/webhook-server && cargo check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,11 +19,12 @@ jobs:
     steps:
     - run: rustup update stable
     - uses: actions/checkout@v2
-    - run: cd rust && cargo fmt -- --check
+    - run: cargo fmt --manifest-path=rust/Cargo.toml -- --check
+    - run: cargo fmt --manifest-path=rust/examples/webhook-server/Cargo.toml -- --check
 
   examples:
     runs-on: ubuntu-latest
     steps:
     - run: rustup update stable
     - uses: actions/checkout@v2
-    - run: cd rust/examples/webhook-server && cargo check
+    - run: cargo check --manifest-path=rust/examples/webhook-server/Cargo.toml

--- a/rust/README.md
+++ b/rust/README.md
@@ -36,3 +36,5 @@ truelayer_signing::verify_with_jwks(jwks)
     .body(body)
     .verify(webhook_signature)?;
 ```
+
+See [webhook server example](./examples/webhook-server/).

--- a/rust/examples/webhook-server/Cargo.toml
+++ b/rust/examples/webhook-server/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "webhook-server"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+tokio = { version = "1.17", features = ["full"] }
+axum = "0.4.8"
+anyhow = "1.0.56"
+truelayer-signing = "0.1.3"
+reqwest = "0.11"
+tracing-subscriber = "0.3.9"
+tracing = "0.1.32"

--- a/rust/examples/webhook-server/Cargo.toml
+++ b/rust/examples/webhook-server/Cargo.toml
@@ -12,3 +12,5 @@ truelayer-signing = "0.1.3"
 reqwest = "0.11"
 tracing-subscriber = "0.3.9"
 tracing = "0.1.32"
+reqwest-middleware = "0.1.5"
+http-cache-reqwest = { version = "0.4", default-features = false, features = ["manager-moka"] }

--- a/rust/examples/webhook-server/README.md
+++ b/rust/examples/webhook-server/README.md
@@ -1,0 +1,19 @@
+# Rust webhook server example
+A http server than can receive and verify signed TrueLayer webhooks.
+
+## Run
+Run the server.
+```sh
+RUST_LOG=info cargo run
+```
+
+Send a valid webhook that was signed for path `/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b`.
+```sh
+curl -iX POST -H "Content-Type: application/json" \
+    -H "X-Tl-Webhook-Timestamp: 2022-03-11T14:00:33Z" \
+    -H "Tl-Signature: eyJhbGciOiJFUzUxMiIsImtpZCI6IjFmYzBlNTlmLWIzMzUtNDdjYS05OWE5LTczNzQ5NTc1NmE1OCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGVhZGVycyI6IngtdGwtd2ViaG9vay10aW1lc3RhbXAiLCJqa3UiOiJodHRwczovL3dlYmhvb2tzLnRydWVsYXllci5jb20vLndlbGwta25vd24vandrcyJ9..AE_QsBRhnsMkcRzd42wvY1e2HruUhkOgjuZKktGH_WmbD7rBzoaEHUuF36IxyyvCbLajd3MBExNmzjbrOQsGaspwAI5DcGVMFLKUhB7ZzUlTP9up3eNUrdwWyyfBWDQb-qmEuLnrhFDJvgCXEqlV5OLrt-O7LaRAJ4f9KHsZLQ_j2vPC" \
+    -d "{\"event_type\":\"payout_settled\",\"event_schema_version\":1,\"event_id\":\"8fb9fb4e-bb2b-400b-af64-59e5dde74bad\",\"event_body\":{\"transaction_id\":\"c34c8721-66a9-49f6-a229-284efcf88a02\",\"settled_at\":\"2022-03-11T14:00:32.933000Z\"}}" \
+    http://localhost:7000/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b
+```
+
+Modifying the `X-Tl-Webhook-Timestamp` header, the body or the path will cause the above signature to be invalid.

--- a/rust/examples/webhook-server/src/main.rs
+++ b/rust/examples/webhook-server/src/main.rs
@@ -1,0 +1,97 @@
+use anyhow::{ensure, Context};
+use axum::{
+    body::Bytes,
+    extract::Extension,
+    http::{request, StatusCode},
+    routing::post,
+    Router,
+};
+use std::net::SocketAddr;
+use tracing::{info, warn};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let client = reqwest::Client::new();
+
+    let app = Router::new()
+        .route(
+            // Note: Webhook path can be whatever is configured, here a unique path
+            // is used matching the README example signature.
+            "/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b",
+            post(receive_hook),
+        )
+        .layer(Extension(client));
+
+    info!("Starting server on :7000");
+
+    axum::Server::bind(&SocketAddr::from(([127, 0, 0, 1], 7000)))
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+async fn receive_hook(
+    Extension(client): Extension<reqwest::Client>,
+    parts: request::Parts,
+    body: Bytes,
+) -> StatusCode {
+    if let Err(err) = verify_hook(&client, &parts, &body).await {
+        warn!("{err}");
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    // handle verified hook
+
+    StatusCode::ACCEPTED
+}
+
+/// Returns `Ok(())` if the webhook `Tl-Signature` is valid.
+async fn verify_hook(
+    client: &reqwest::Client,
+    parts: &request::Parts,
+    body: &Bytes,
+) -> anyhow::Result<()> {
+    let tl_signature = parts
+        .headers
+        .get("Tl-Signature")
+        .context("missing Tl-Signature headers")?
+        .to_str()
+        .context("invalid non-string Tl-Signature")?;
+
+    let jku = truelayer_signing::extract_jws_header(tl_signature)?
+        .jku
+        .context("jku missing")?;
+
+    // ensure jku is an expected TrueLayer url
+    ensure!(
+        jku == "https://webhooks.truelayer.com/.well-known/jwks"
+            || jku == "https://webhooks.truelayer-sandbox.com/.well-known/jwks",
+        "Unpermitted jku {jku}"
+    );
+
+    // fetch jwks (should cache this according to cache-control headers)
+    let jwks = client
+        .get(jku)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+
+    // verify signature using the jwks
+    truelayer_signing::verify_with_jwks(&jwks)
+        .method("POST")
+        .path(parts.uri.path())
+        .headers(
+            parts
+                .headers
+                .iter()
+                .map(|(h, v)| (h.as_str(), v.as_bytes())),
+        )
+        .body(body)
+        .verify(tl_signature)?;
+
+    Ok(())
+}

--- a/rust/examples/webhook-server/src/main.rs
+++ b/rust/examples/webhook-server/src/main.rs
@@ -79,7 +79,7 @@ async fn verify_hook(
         "Unpermitted jku {jku}"
     );
 
-    // fetch jwks (should cache this according to cache-control headers)
+    // fetch jwks (cached according to cache-control headers)
     let jwks = client
         .get(jku)
         .send()


### PR DESCRIPTION
#47 for Rust, including jwks fetch caching.

# Rust webhook server example
A http server than can receive and verify signed TrueLayer webhooks.

## Run
Run the server.
```sh
RUST_LOG=info cargo run
```

Send a valid webhook that was signed for path `/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b`.
```sh
curl -iX POST -H "Content-Type: application/json" \
    -H "X-Tl-Webhook-Timestamp: 2022-03-11T14:00:33Z" \
    -H "Tl-Signature: eyJhbGciOiJFUzUxMiIsImtpZCI6IjFmYzBlNTlmLWIzMzUtNDdjYS05OWE5LTczNzQ5NTc1NmE1OCIsInRsX3ZlcnNpb24iOiIyIiwidGxfaGVhZGVycyI6IngtdGwtd2ViaG9vay10aW1lc3RhbXAiLCJqa3UiOiJodHRwczovL3dlYmhvb2tzLnRydWVsYXllci5jb20vLndlbGwta25vd24vandrcyJ9..AE_QsBRhnsMkcRzd42wvY1e2HruUhkOgjuZKktGH_WmbD7rBzoaEHUuF36IxyyvCbLajd3MBExNmzjbrOQsGaspwAI5DcGVMFLKUhB7ZzUlTP9up3eNUrdwWyyfBWDQb-qmEuLnrhFDJvgCXEqlV5OLrt-O7LaRAJ4f9KHsZLQ_j2vPC" \
    -d "{\"event_type\":\"payout_settled\",\"event_schema_version\":1,\"event_id\":\"8fb9fb4e-bb2b-400b-af64-59e5dde74bad\",\"event_body\":{\"transaction_id\":\"c34c8721-66a9-49f6-a229-284efcf88a02\",\"settled_at\":\"2022-03-11T14:00:32.933000Z\"}}" \
    http://localhost:7000/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b
```

Modifying the `X-Tl-Webhook-Timestamp` header, the body or the path will cause the above signature to be invalid.
