### PR TITLE
Add C# request signature example

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -27,3 +27,4 @@ jobs:
       with:
         dotnet-version: '6.0.x'
     - run: cd csharp/examples/webhook-server && dotnet build
+    - run: cd csharp/examples/sign-request && dotnet build

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -15,6 +15,8 @@ var tlSignature = Signer.SignWithPem(kid, privateKey)
     .Sign();
 ```
 
+See [full example](./examples/sign-request/).
+
 ## Verifying webhooks
 The `VerifyWithJwks` function may be used to verify webhook `Tl-Signature` header signatures.
  

--- a/csharp/examples/sign-request/ExampleSignRequest.csproj
+++ b/csharp/examples/sign-request/ExampleSignRequest.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>9</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\truelayer-signing.csproj" />
+  </ItemGroup>
+</Project>

--- a/csharp/examples/sign-request/Program.cs
+++ b/csharp/examples/sign-request/Program.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using TrueLayer.Signing;
+
+namespace TrueLayer.ExampleWebhookServer
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            // Read required env vars
+            var accessToken = System.Environment.GetEnvironmentVariable("ACCESS_TOKEN")
+                ?? throw new System.Exception("Missing env var ACCESS_TOKEN");
+            var kid = System.Environment.GetEnvironmentVariable("KID")
+                ?? throw new System.Exception("Missing env var KID");
+            var privateKeyPem = System.Environment.GetEnvironmentVariable("PRIVATE_KEY")
+                ?? throw new System.Exception("Missing env var PRIVATE_KEY");
+
+            // We use a random body string for our request as `/test-signature` endpoint does not 
+            // require any schema, it simply checks the signature is valid.
+            var body = $"msg-{new Random().Next()}";
+            var idempotencyKey = Guid.NewGuid().ToString();
+
+            var tlSignature = Signer.SignWithPem(kid, privateKeyPem)
+                .Method("POST") // as we're sending a POST request
+                .Path("/test-signature") // the path of our request
+                // Optional: /test-signature does not require any headers, but we may sign some anyway.
+                // All signed headers *must* be included unmodified in the request.
+                .Header("Idempotency-Key", idempotencyKey)
+                .Header("X-Foo-Header", "abc123")
+                .Body(body) // body of our request
+                .Sign();
+
+            var request = new HttpRequestMessage(HttpMethod.Post, "https://api.truelayer-sandbox.com/test-signature");
+            // Request body & any signed headers *must* exactly match what was used to generate the signature.
+            request.Content = new StringContent(body, Encoding.UTF8);
+            request.Headers.Add("Idempotency-Key", idempotencyKey);
+            request.Headers.Add("Authorization", $"Bearer {accessToken}");
+            request.Headers.Add("X-Foo-Header", "abc123");
+            request.Headers.Add("Tl-Signature", tlSignature);
+
+            Console.WriteLine($"Sending {request}\nbody: {body}\n");
+
+            var response = new HttpClient().Send(request);
+            var responseBody = response.IsSuccessStatusCode ? "✓" : response.Content.ReadAsStringAsync().Result;
+            // 204 means success
+            // 401 means either the access token is invalid, or the signature is invalid.
+            Console.WriteLine($"{(int)response.StatusCode} {responseBody}");
+        }
+    }
+}

--- a/csharp/examples/sign-request/Program.cs
+++ b/csharp/examples/sign-request/Program.cs
@@ -10,12 +10,12 @@ namespace TrueLayer.ExampleWebhookServer
         public static void Main(string[] args)
         {
             // Read required env vars
-            var accessToken = System.Environment.GetEnvironmentVariable("ACCESS_TOKEN")
-                ?? throw new System.Exception("Missing env var ACCESS_TOKEN");
-            var kid = System.Environment.GetEnvironmentVariable("KID")
-                ?? throw new System.Exception("Missing env var KID");
-            var privateKeyPem = System.Environment.GetEnvironmentVariable("PRIVATE_KEY")
-                ?? throw new System.Exception("Missing env var PRIVATE_KEY");
+            var accessToken = Environment.GetEnvironmentVariable("ACCESS_TOKEN")
+                ?? throw new Exception("Missing env var ACCESS_TOKEN");
+            var kid = Environment.GetEnvironmentVariable("KID")
+                ?? throw new Exception("Missing env var KID");
+            var privateKeyPem = Environment.GetEnvironmentVariable("PRIVATE_KEY")
+                ?? throw new Exception("Missing env var PRIVATE_KEY");
 
             // A random body string is enough for this request as `/test-signature` endpoint does not 
             // require any schema, it simply checks the signature is valid against what's received.

--- a/csharp/examples/sign-request/Program.cs
+++ b/csharp/examples/sign-request/Program.cs
@@ -17,8 +17,8 @@ namespace TrueLayer.ExampleWebhookServer
             var privateKeyPem = System.Environment.GetEnvironmentVariable("PRIVATE_KEY")
                 ?? throw new System.Exception("Missing env var PRIVATE_KEY");
 
-            // We use a random body string for our request as `/test-signature` endpoint does not 
-            // require any schema, it simply checks the signature is valid.
+            // A random body string is enough for this request as `/test-signature` endpoint does not 
+            // require any schema, it simply checks the signature is valid against what's received.
             var body = $"msg-{new Random().Next()}";
             var idempotencyKey = Guid.NewGuid().ToString();
 

--- a/csharp/examples/sign-request/README.md
+++ b/csharp/examples/sign-request/README.md
@@ -3,9 +3,10 @@ Sends a signed request to `https://api.truelayer-sandbox.com/test-signature`.
 
 ## Run
 Set environment variables:
-* `ACCESS_TOKEN` A valid access token for `payments` scope [docs](https://docs.truelayer.com/docs/retrieve-a-token-in-your-server).
-* `KID` The certificate/key ID for associated with your public key uploaded to console.truelayer.com.
+* `ACCESS_TOKEN` A valid JWT access token for `payments` scope [docs](https://docs.truelayer.com/docs/retrieve-a-token-in-your-server).
+* `KID` The certificate/key UUID for associated with your public key uploaded to console.truelayer.com.
 * `PRIVATE_KEY` Private key PEM string that matches the `KID` & uploaded public key.
+  Should have the same format as [this example private key](../../../test-resources/ec512-private.pem).
 
 ```sh
 $ dotnet run

--- a/csharp/examples/sign-request/README.md
+++ b/csharp/examples/sign-request/README.md
@@ -1,0 +1,13 @@
+# C# request signature example
+Sends a signed request to `https://api.truelayer-sandbox.com/test-signature`.
+
+## Run
+Set environment variables:
+* `ACCESS_TOKEN` A valid access token for `payments` scope [docs](https://docs.truelayer.com/docs/retrieve-a-token-in-your-server).
+* `KID` The certificate/key ID for associated with your public key uploaded to console.truelayer.com.
+* `PRIVATE_KEY` Private key PEM string that matches the `KID` & uploaded public key.
+
+```sh
+$ dotnet run
+204 ✓
+```

--- a/csharp/examples/sign-request/README.md
+++ b/csharp/examples/sign-request/README.md
@@ -10,5 +10,7 @@ Set environment variables:
 
 ```sh
 $ dotnet run
+Sending ...
+
 204 ✓
 ```


### PR DESCRIPTION
#51 for C#

# C# request signature example
Sends a signed request to `https://api.truelayer-sandbox.com/test-signature`.

## Run
Set environment variables:
* `ACCESS_TOKEN` A valid JWT access token for `payments` scope [docs](https://docs.truelayer.com/docs/retrieve-a-token-in-your-server).
* `KID` The certificate/key UUID for associated with your public key uploaded to console.truelayer.com.
* `PRIVATE_KEY` Private key PEM string that matches the `KID` & uploaded public key.
  Should have the same format as [this example private key](https://github.com/TrueLayer/truelayer-signing/blob/main/test-resources/ec512-private.pem).

```sh
$ dotnet run
Sending ...

204 ✓
```
