### PR TITLE
[PAYG-723] Adds rust tl-signature example

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,2 +1,2 @@
-/target
+**/target
 Cargo.lock

--- a/rust/README.md
+++ b/rust/README.md
@@ -14,6 +14,8 @@ let tl_signature = truelayer_signing::sign_with_pem(kid, private_key)
     .sign()?;
 ```
 
+See [full example](./examples/sign-request/).
+
 ## Prerequisites
 - OpenSSL (see [here](https://www.openssl.org/) for instructions).
 

--- a/rust/examples/sign-request/Cargo.toml
+++ b/rust/examples/sign-request/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sign-request"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+rand = "0.8.4"
+reqwest = "0.11"
+tokio = { version = "1.17", features = ["full"] }
+truelayer-signing = "0.1.3"
+uuid = { version = "0.8", features = ["v4"] }

--- a/rust/examples/sign-request/README.md
+++ b/rust/examples/sign-request/README.md
@@ -1,0 +1,14 @@
+# rust request signature example
+Sends a signed request to `https://api.truelayer-sandbox.com/test-signature`.
+
+## Run
+
+Set environment variables:
+* `ACCESS_TOKEN` A valid JWT access token for `payments` scope [docs](https://docs.truelayer.com/docs/retrieve-a-token-in-your-server).
+* `KID` The certificate/key UUID for associated with your public key uploaded to console.truelayer.com.
+* `PRIVATE_KEY` Private key PEM string that matches the `KID` & uploaded public key.
+  Should have the same format as [this example private key](https://github.com/TrueLayer/truelayer-signing/blob/main/test-resources/ec512-private.pem).
+
+```sh
+$ cargo run
+```

--- a/rust/examples/sign-request/src/main.rs
+++ b/rust/examples/sign-request/src/main.rs
@@ -1,0 +1,50 @@
+use rand;
+use std::env;
+use uuid::Uuid;
+
+const KID: &str = "KID";
+const ACCESS_TOKEN: &str = "ACCESS_TOKEN";
+const PRIVATE_KEY: &str = "PRIVATE_KEY";
+
+const URL: &str = "https://api.truelayer-sandbox.com/test-signature";
+
+#[tokio::main]
+async fn main() {
+    // load env vars
+    let kid = env::var(KID).expect("Missing env var KID");
+    let access_token = env::var(ACCESS_TOKEN).expect("Missing env var ACCESS_TOKEN");
+    let private_key = env::var(PRIVATE_KEY).expect("Missing env var PRIVATE_KEY");
+
+    // create idemoptency key and body
+    let idempotency_key = Uuid::new_v4().to_string();
+    let body = format!("body-{}", rand::random::<u32>());
+
+    // generate tl-signature
+    let tl_signature = truelayer_signing::sign_with_pem(kid.as_str(), private_key.as_bytes())
+        .method("POST")
+        .path("/test-signature")
+        .header("Idempotency-Key", idempotency_key.as_bytes())
+        .header("X-Bar-Header", b"abc123")
+        .body(body.as_bytes())
+        .sign()
+        .unwrap();
+
+    // call `/test-signature` endpoint
+    let client = reqwest::Client::new();
+    let response = client
+        .post(URL)
+        .header("Authorization", format!("Bearer {access_token}"))
+        .header("Idempotency-Key", idempotency_key)
+        .header("X-Bar-Header", "abc123")
+        .header("Tl-Signature", tl_signature)
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+
+    // print result
+    match response.error_for_status_ref() {
+        Ok(res) => println!("{} ✓", res.status()),
+        Err(err) => println!("{}", err.status().unwrap()),
+    }
+}

--- a/rust/examples/sign-request/src/main.rs
+++ b/rust/examples/sign-request/src/main.rs
@@ -7,27 +7,31 @@ const TL_BASE_URL: &str = "https://api.truelayer-sandbox.com";
 
 #[tokio::main]
 async fn main() {
-    // load env vars
+    // Read required env vars
     let kid = env::var("KID").expect("Missing env var KID");
     let access_token = env::var("ACCESS_TOKEN").expect("Missing env var ACCESS_TOKEN");
     let private_key = env::var("PRIVATE_KEY").expect("Missing env var PRIVATE_KEY");
 
-    // create idemoptency key and body
-    let idempotency_key = Uuid::new_v4().to_string();
+    // A random body string is enough for this request as `/test-signature` endpoint does not
+    // require any schema, it simply checks the signature is valid against what's received.
     let body = format!("body-{}", rand::random::<u32>());
 
-    // generate tl-signature
+    let idempotency_key = Uuid::new_v4().to_string();
+
+    // Generate tl-signature
     let tl_signature = truelayer_signing::sign_with_pem(kid.as_str(), private_key.as_bytes())
-        .method("POST")
-        .path("/test-signature")
+        .method("POST") // as we're sending a POST request
+        .path("/test-signature") // the path of our request
+        // Optional: /test-signature does not require any headers, but we may sign some anyway.
+        // All signed headers *must* be included unmodified in the request.
         .header("Idempotency-Key", idempotency_key.as_bytes())
         .header("X-Bar-Header", b"abc123")
-        .body(body.as_bytes())
+        .body(body.as_bytes()) // body of our request
         .sign()
         .unwrap();
 
-    // call `/test-signature` endpoint
     let client = reqwest::Client::new();
+    // Request body & any signed headers *must* exactly match what was used to generate the signature.
     let response = client
         .post(format!("{}/test-signature", TL_BASE_URL))
         .header("Authorization", format!("Bearer {access_token}"))
@@ -39,13 +43,13 @@ async fn main() {
         .await
         .unwrap();
 
-    // print result
-    match response.error_for_status_ref() {
-        Ok(res) => println!("{} ✓", res.status()),
-        Err(err) => println!(
-            "{}: {}",
-            err.status().unwrap(),
-            response.text().await.unwrap()
-        ),
-    }
+    let status = response.status();
+    let response_body = match status.is_success() {
+        true => String::from("✓"),
+        false => response.text().await.unwrap(),
+    };
+
+    // 204 means success
+    // 401 means either the access token is invalid, or the signature is invalid.
+    println!("{} {}", status.as_u16(), response_body);
 }

--- a/rust/examples/sign-request/src/main.rs
+++ b/rust/examples/sign-request/src/main.rs
@@ -2,11 +2,8 @@ use rand;
 use std::env;
 use uuid::Uuid;
 
-const KID: &str = "KID";
-const ACCESS_TOKEN: &str = "ACCESS_TOKEN";
-const PRIVATE_KEY: &str = "PRIVATE_KEY";
-
-const URL: &str = "https://api.truelayer-sandbox.com/test-signature";
+// the base url to use
+const TL_BASE_URL: &str = "https://api.truelayer-sandbox.com";
 
 #[tokio::main]
 async fn main() {
@@ -32,7 +29,7 @@ async fn main() {
     // call `/test-signature` endpoint
     let client = reqwest::Client::new();
     let response = client
-        .post(URL)
+        .post(format!("{}/test-signature", TL_BASE_URL))
         .header("Authorization", format!("Bearer {access_token}"))
         .header("Idempotency-Key", idempotency_key)
         .header("X-Bar-Header", "abc123")
@@ -45,6 +42,10 @@ async fn main() {
     // print result
     match response.error_for_status_ref() {
         Ok(res) => println!("{} ✓", res.status()),
-        Err(err) => println!("{}", err.status().unwrap()),
+        Err(err) => println!(
+            "{}: {}",
+            err.status().unwrap(),
+            response.text().await.unwrap()
+        ),
     }
 }

--- a/rust/examples/sign-request/src/main.rs
+++ b/rust/examples/sign-request/src/main.rs
@@ -11,9 +11,9 @@ const URL: &str = "https://api.truelayer-sandbox.com/test-signature";
 #[tokio::main]
 async fn main() {
     // load env vars
-    let kid = env::var(KID).expect("Missing env var KID");
-    let access_token = env::var(ACCESS_TOKEN).expect("Missing env var ACCESS_TOKEN");
-    let private_key = env::var(PRIVATE_KEY).expect("Missing env var PRIVATE_KEY");
+    let kid = env::var("KID").expect("Missing env var KID");
+    let access_token = env::var("ACCESS_TOKEN").expect("Missing env var ACCESS_TOKEN");
+    let private_key = env::var("PRIVATE_KEY").expect("Missing env var PRIVATE_KEY");
 
     // create idemoptency key and body
     let idempotency_key = Uuid::new_v4().to_string();


### PR DESCRIPTION
#51 for Rust

# Rust request signature example
Sends a signed request to `https://api.truelayer-sandbox.com/test-signature`.

## Run
Set environment variables:
* `ACCESS_TOKEN` A valid JWT access token for `payments` scope [docs](https://docs.truelayer.com/docs/retrieve-a-token-in-your-server).
* `KID` The certificate/key UUID for associated with your public key uploaded to console.truelayer.com.
* `PRIVATE_KEY` Private key PEM string that matches the `KID` & uploaded public key.
  Should have the same format as [this example private key](https://github.com/TrueLayer/truelayer-signing/blob/main/test-resources/ec512-private.pem).

```sh
$ cargo run
204 No Content ✓
```