### PR TITLE
[dotnet] Fix VerifyWithJwks

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.8
+* Fix VerifyWithJwks for pre .NET 5 versions.
+
 ## 0.1.7
-* Add support for .NET Standard 2.0. 
+* Add support for .NET Standard 2.0.
 
 ## 0.1.6
 * Fix issue parsing jwks with uneven EC coord byte lengths.

--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -239,7 +239,7 @@ namespace TrueLayer.Signing
 
             SignatureException.TryAction(() => key.ImportParameters(new ECParameters
             {
-                Curve = ECCurve.CreateFromFriendlyName("secp521r1"),
+                Curve = ECCurve.NamedCurves.nistP521,
                 Q = new ECPoint
                 {
                     // Note: A CryptographicException will be thrown if the coord byte

--- a/csharp/src/truelayer-signing.csproj
+++ b/csharp/src/truelayer-signing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageVersion>0.1.7</PackageVersion>
+    <PackageVersion>0.1.8</PackageVersion>
     <TargetFrameworks>net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Although all tests pass in CI, locally on my Macbook the `Verify_Jwks` tests fail for all targets other than .NET 5. For example the .NET Core 3.1 tests error with:
```
System.Security.Cryptography.CryptographicException
No OID value matches this name.
   at System.Security.Cryptography.Oid.FromFriendlyName(String friendlyName, OidGroup group)
   at System.Security.Cryptography.EccKeyFormatHelper.WriteEcParameters(ECParameters& ecParameters, AsnWriter writer)
   at System.Security.Cryptography.EccKeyFormatHelper.WriteAlgorithmIdentifier(ECParameters& ecParameters, AsnWriter writer)
   at System.Security.Cryptography.EccKeyFormatHelper.WriteSubjectPublicKeyInfo(ECParameters& ecParameters)
   at System.Security.Cryptography.EccSecurityTransforms.ImportKey(ECParameters parameters)
   at System.Security.Cryptography.EccSecurityTransforms.ImportParameters(ECParameters parameters)
   at System.Security.Cryptography.ECDsa.ECDsaImplementation.ECDsaSecurityTransforms.ImportParameters(ECParameters parameters)
   at TrueLayer.Signing.Verifier.<>c__DisplayClass26_0.<FindAndImportJwk>b__1() in /<redacted>/truelayer-signing/csharp/src/Verifier.cs:line 240
   at TrueLayer.Signing.SignatureException.<>c__DisplayClass2_0.<TryAction>b__0() in /<redacted>/truelayer-signing/csharp/src/Util.cs:line 46
   at TrueLayer.Signing.SignatureException.Try[T](Func`1 f, String message) in /<redacted>/truelayer-signing/csharp/src/Util.cs:line 27
```
That occurs on [this line](https://github.com/TrueLayer/truelayer-signing/blob/9aa14091f626d9a59526ad35b0d5def28a2d6876/csharp/test/UsageTest.cs#L270-L276) of the test:
```
            Verifier.VerifyWithJwks(jwks)
                .Method("POST")
                .Path("/tl-webhook")
                .Header("x-tl-webhook-timestamp", "2021-11-29T11:42:55Z")
                .Header("content-type", "application/json")
                .Body("{\"event_type\":\"example\",\"event_id\":\"18b2842b-a57b-4887-a0a6-d3c7c36f1020\"}")
                .Verify(tlSignature); // should not throw
```

Switching from `ECCurve.CreateFromFriendlyName("secp521r1")` to `ECCurve.NamedCurves.nistP521` fixes this locally and CI still passes.

Perhaps this isa platform specific thing (CI runs on Ubuntu)