### PR TITLE
[MAP-101] Add Golang request signature example

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,4 +33,4 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.14'
-    - run: cd go/examples/sign-request && go build main
+    - run: cd go/examples/sign-request && go build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,3 +26,11 @@ jobs:
         with:
           go-version: '^1.14'
       - run: cd go && go test ./...
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.14'
+    - run: cd go/examples/sign-request && go build main

--- a/go/examples/sign-request/README.md
+++ b/go/examples/sign-request/README.md
@@ -1,4 +1,4 @@
-# golang request signature example
+# Golang request signature example
 Sends a signed request to `https://api.truelayer-sandbox.com/test-signature`.
 
 ## Run

--- a/go/examples/sign-request/README.md
+++ b/go/examples/sign-request/README.md
@@ -1,0 +1,14 @@
+# golang request signature example
+Sends a signed request to `https://api.truelayer-sandbox.com/test-signature`.
+
+## Run
+
+Set environment variables:
+* `ACCESS_TOKEN` A valid JWT access token for `payments` scope [docs](https://docs.truelayer.com/docs/retrieve-a-token-in-your-server).
+* `KID` The certificate/key UUID for associated with your public key uploaded to console.truelayer.com.
+* `PRIVATE_KEY` Private key PEM string that matches the `KID` & uploaded public key.
+  Should have the same format as [this example private key](https://github.com/TrueLayer/truelayer-signing/blob/main/test-resources/ec512-private.pem).
+
+```sh
+$ go run main.go
+```

--- a/go/examples/sign-request/go.mod
+++ b/go/examples/sign-request/go.mod
@@ -1,0 +1,9 @@
+module sign-request
+
+go 1.18
+
+require (
+	github.com/Truelayer/truelayer-signing/go v0.1.4 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/wk8/go-ordered-map v0.2.0 // indirect
+)

--- a/go/examples/sign-request/go.sum
+++ b/go/examples/sign-request/go.sum
@@ -1,0 +1,13 @@
+github.com/Truelayer/truelayer-signing/go v0.1.4 h1:tdYr7J8orPEUlrVJ4g922V0OVr+Px4QDOxaHbOcbI7w=
+github.com/Truelayer/truelayer-signing/go v0.1.4/go.mod h1:SWksk9wzvQRhn0rb8Q0drHt9N0w67pvTg0PWBdQ+cWk=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/wk8/go-ordered-map v0.2.0 h1:KlvGyHstD1kkGZkPtHCyCfRYS0cz84uk6rrW/Dnhdtk=
+github.com/wk8/go-ordered-map v0.2.0/go.mod h1:9ZIbRunKbuvfPKyBP1SIKLcXNlv74YCOZ3t3VTS6gRk=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go/examples/sign-request/main.go
+++ b/go/examples/sign-request/main.go
@@ -52,9 +52,10 @@ func main() {
 		Body([]byte(body)). // body of our request
 		Sign()
 
-	client := &http.Client{}
+	fmt.Println("Sending...")
 
 	// Request body & any signed headers *must* exactly match what was used to generate the signature.
+	client := &http.Client{}
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/test-signature", TlBaseUrl), strings.NewReader(body))
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 	req.Header.Add("Idempotency-Key", idempotencyKey)
@@ -81,5 +82,5 @@ func main() {
 
 	// 204 means success
 	// 401 means either the access token is invalid, or the signature is invalid.
-	fmt.Printf("%d %s", statusCode, responseBody)
+	fmt.Printf("%d %s\n", statusCode, responseBody)
 }

--- a/go/examples/sign-request/main.go
+++ b/go/examples/sign-request/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"os"
+	"strings"
+
+	tlsigning "github.com/Truelayer/truelayer-signing/go"
+	"github.com/google/uuid"
+)
+
+// the base url to use
+const (
+	TlBaseUrl = "https://api.truelayer-sandbox.com"
+)
+
+func main() {
+	// Read required env vars
+	kid, found := os.LookupEnv("KID")
+	if !found {
+		fmt.Println("Missing env var KID")
+		os.Exit(1)
+	}
+	accessToken, found := os.LookupEnv("ACCESS_TOKEN")
+	if !found {
+		fmt.Println("Missing env var ACCESS_TOKEN")
+		os.Exit(1)
+	}
+	privateKey, found := os.LookupEnv("PRIVATE_KEY")
+	if !found {
+		fmt.Println("Missing env var PRIVATE_KEY")
+		os.Exit(1)
+	}
+
+	// A random body string is enough for this request as `/test-signature` endpoint does not
+	// require any schema, it simply checks the signature is valid against what's received.
+	body := fmt.Sprintf("body-%d", rand.Intn(99999999))
+
+	idempotencyKey := uuid.New().String()
+
+	// Generate tl-signature
+	tlSignature, err := tlsigning.SignWithPem(kid, []byte(privateKey)).
+		Method("POST"). // as we're sending a POST request
+		Path("/test-signature").
+		// Optional: /test-signature does not require any headers, but we may sign some anyway.
+		// All signed headers *must* be included unmodified in the request.
+		Header("Idempotency-Key", []byte(idempotencyKey)).
+		Header("X-Bar-Header", []byte("abc123")).
+		Body([]byte(body)). // body of our request
+		Sign()
+
+	client := &http.Client{}
+
+	// Request body & any signed headers *must* exactly match what was used to generate the signature.
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/test-signature", TlBaseUrl), strings.NewReader(body))
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+	req.Header.Add("Idempotency-Key", idempotencyKey)
+	req.Header.Add("X-Bar-Header", "abc123")
+	req.Header.Add("Tl-Signature", tlSignature)
+	resp, err := client.Do(req)
+
+	statusCode := resp.StatusCode
+
+	var responseBody []byte
+	if err == nil {
+		if statusCode == 204 {
+			responseBody = []byte("✓")
+		} else {
+			defer resp.Body.Close()
+			responseBody, err = io.ReadAll(resp.Body)
+			if err != nil {
+				responseBody = []byte(fmt.Sprintf("%s", err.Error()))
+			}
+		}
+	} else {
+		responseBody = []byte(fmt.Sprintf("%s", err.Error()))
+	}
+
+	// 204 means success
+	// 401 means either the access token is invalid, or the signature is invalid.
+	fmt.Printf("%d %s", statusCode, responseBody)
+}

--- a/go/examples/sign-request/main.go
+++ b/go/examples/sign-request/main.go
@@ -75,7 +75,7 @@ func main() {
 	statusCode := -1
 	var responseBody string
 	if err == nil {
-		statusCode := resp.StatusCode
+		statusCode = resp.StatusCode
 		if statusCode == 204 {
 			responseBody = "✓"
 		} else {


### PR DESCRIPTION
#51 for Golang

# Golang request signature example
Sends a signed request to `https://api.truelayer-sandbox.com/test-signature`.

## Run
Set environment variables:
* `ACCESS_TOKEN` A valid JWT access token for `payments` scope [docs](https://docs.truelayer.com/docs/retrieve-a-token-in-your-server).
* `KID` The certificate/key UUID for associated with your public key uploaded to console.truelayer.com.
* `PRIVATE_KEY` Private key PEM string that matches the `KID` & uploaded public key.
  Should have the same format as [this example private key](https://github.com/TrueLayer/truelayer-signing/blob/main/test-resources/ec512-private.pem).

```sh
$ go run main.go
Sending...
204 ✓
```
