### PR TITLE
Golang: Add path arg validation to Signer & Verifier

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.1.5
+* Add `path` arg validation to `Signer` & `Verifier` for more informative errors.
 * Fixed README example
 * Removed license symlinks
 

--- a/go/errors/errors.go
+++ b/go/errors/errors.go
@@ -31,3 +31,18 @@ func NewJwsError(msg string) *JwsError {
 func (e *JwsError) Error() string {
 	return e.message
 }
+
+// Argument invalid
+type InvalidArgumentError struct {
+	message string
+}
+
+func NewInvalidArgumentError(msg string) *InvalidArgumentError {
+	return &InvalidArgumentError{
+		message: fmt.Sprintf("invalid argument: %s", msg),
+	}
+}
+
+func (e *InvalidArgumentError) Error() string {
+	return e.message
+}

--- a/go/sign/signer.go
+++ b/go/sign/signer.go
@@ -87,6 +87,10 @@ func (s *Signer) AddHeader(name string, value []byte) {
 
 // Sign produces a JWS 'Tl-Signature' v2 header value.
 func (s *Signer) Sign() (string, error) {
+	if !strings.HasPrefix(s.path, "/") {
+		return "", errors.NewInvalidArgumentError("path must start with '/'")
+	}
+
 	privateKey, err := crypto.ParseEcPrivateKey(s.privateKey)
 	if err != nil {
 		return "", errors.NewInvalidKeyError(fmt.Sprintf("private key parsing failed: %v", err))

--- a/go/tlsigning_test.go
+++ b/go/tlsigning_test.go
@@ -424,3 +424,32 @@ func TestHeadersMethod(t *testing.T) {
 		Verify(signature)
 	assert.Nilf(err, "signature verification should not fail: %v", err)
 }
+
+func TestInvalidSignerPath(t *testing.T) {
+	assert := assert.New(t)
+
+	privateKeyBytes, _ := getTestKeys(assert)
+	path := "https://example.com/the-path"
+
+	_, err := SignWithPem(Kid, privateKeyBytes).
+		Method("post").
+		Path(path).
+		Sign()
+	assert.NotNilf(err, "signing should fail: %v", err)
+	assert.ErrorAs(&errors.InvalidArgumentError{}, &err, "error should be an InvalidArgumentError")
+}
+
+func TestInvalidVerifierPath(t *testing.T) {
+	assert := assert.New(t)
+
+	_, publicKeyBytes := getTestKeys(assert)
+	path := "https://example.com/the-path"
+	signature := "signature"
+
+	err := VerifyWithPem(publicKeyBytes).
+		Method("POST").
+		Path(path).
+		Verify(signature)
+	assert.NotNilf(err, "signature verification should fail: %v", err)
+	assert.ErrorAs(&errors.InvalidArgumentError{}, &err, "error should be an InvalidArgumentError")
+}

--- a/go/verify/verifier.go
+++ b/go/verify/verifier.go
@@ -105,6 +105,10 @@ func (v *Verifier) RequireHeader(name string) *Verifier {
 //
 // Returns error if verification fails.
 func (v *Verifier) Verify(tlSignature string) error {
+	if !strings.HasPrefix(v.path, "/") {
+		return errors.NewInvalidArgumentError("path must start with '/'")
+	}
+
 	tlSignatureData, err := ParseTlSignature(tlSignature)
 	if err != nil {
 		return errors.NewJwsError(fmt.Sprintf("signature parsing failed: %v", err))


### PR DESCRIPTION
https://github.com/TrueLayer/truelayer-signing/issues/69 for Golang