### PR TITLE
Golang: Add `Jku` method to `Signer`

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.6
+* Added `Jku` method to `Signer` to allow different jku's endpoints.
+
 ## 0.1.5
 * Add `path` arg validation to `Signer` & `Verifier` for more informative errors.
 * Fixed README example

--- a/go/jws/jws_header.go
+++ b/go/jws/jws_header.go
@@ -17,7 +17,7 @@ type JwsHeader struct {
 	Jku       string `json:"jku"`        // Json Web Key Url. Used in webhook signatures providing the public key jwk url.
 }
 
-func NewJwsHeaderV2(kid string, headers *orderedmap.OrderedMap) JwsHeader {
+func NewJwsHeaderV2(kid string, headers *orderedmap.OrderedMap, jku string) JwsHeader {
 	headerKeys := ""
 	for pair := headers.Oldest(); pair != nil; pair = pair.Next() {
 		header := pair.Value.(*tlhttp.Header)
@@ -32,6 +32,7 @@ func NewJwsHeaderV2(kid string, headers *orderedmap.OrderedMap) JwsHeader {
 		Kid:       kid,
 		TlVersion: "2",
 		TlHeaders: headerKeys,
+		Jku:       jku,
 	}
 }
 

--- a/go/jws/jws_header.go
+++ b/go/jws/jws_header.go
@@ -10,11 +10,11 @@ import (
 
 // Tl-Signature header.
 type JwsHeader struct {
-	Alg       string `json:"alg"`        // algorithm, should be "ES512".
-	Kid       string `json:"kid"`        // signing key id.
-	TlVersion string `json:"tl_version"` // signing scheme version, e.g. "2", empty implies v1 aka body-only signing.
-	TlHeaders string `json:"tl_headers"` // comma separated ordered headers used in the signature.
-	Jku       string `json:"jku"`        // Json Web Key Url. Used in webhook signatures providing the public key jwk url.
+	Alg       string `json:"alg"`           // algorithm, should be "ES512".
+	Kid       string `json:"kid"`           // signing key id.
+	TlVersion string `json:"tl_version"`    // signing scheme version, e.g. "2", empty implies v1 aka body-only signing.
+	TlHeaders string `json:"tl_headers"`    // comma separated ordered headers used in the signature.
+	Jku       string `json:"jku,omitempty"` // Json Web Key Url. Used in webhook signatures providing the public key jwk url.
 }
 
 func NewJwsHeaderV2(kid string, headers *orderedmap.OrderedMap, jku string) JwsHeader {

--- a/go/sign/signer.go
+++ b/go/sign/signer.go
@@ -21,6 +21,7 @@ type Signer struct {
 	method     string
 	path       string
 	headers    *orderedmap.OrderedMap
+	jwsJku     string
 }
 
 func NewSigner(kid string, privateKeyPem []byte) *Signer {
@@ -31,6 +32,7 @@ func NewSigner(kid string, privateKeyPem []byte) *Signer {
 		path:       "",
 		body:       []byte(""),
 		headers:    orderedmap.New(),
+		jwsJku:     "",
 	}
 }
 
@@ -85,6 +87,11 @@ func (s *Signer) AddHeader(name string, value []byte) {
 	s.headers.Set(strings.ToLower(name), header)
 }
 
+func (s *Signer) Jku(jku string) *Signer {
+	s.jwsJku = jku
+	return s
+}
+
 // Sign produces a JWS 'Tl-Signature' v2 header value.
 func (s *Signer) Sign() (string, error) {
 	if !strings.HasPrefix(s.path, "/") {
@@ -95,7 +102,7 @@ func (s *Signer) Sign() (string, error) {
 	if err != nil {
 		return "", errors.NewInvalidKeyError(fmt.Sprintf("private key parsing failed: %v", err))
 	}
-	jwsHeader := jws.NewJwsHeaderV2(s.kid, s.headers)
+	jwsHeader := jws.NewJwsHeaderV2(s.kid, s.headers, s.jwsJku)
 	marshalledJwsHeader, err := json.Marshal(jwsHeader)
 	if err != nil {
 		return "", errors.NewJwsError(fmt.Sprintf("jws header json marshalling failed: %v", err))


### PR DESCRIPTION
This PR adds `Jku` method to `Signer` to allow different jku endpoints, just like `rust` implementation.