### PR TITLE
nodejs: validate body string type

### DIFF
--- a/nodejs/CHANGELOG.md
+++ b/nodejs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.4
+* Add `sign` validation that body is a string.
+
 ## 0.1.3
 * Add `path` arg validation to `sign` & `verify` for more informative errors.
 

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truelayer-signing",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Produce & verify TrueLayer API requests signatures",
   "main": "lib/lib.js",
   "types": "lib/lib.d.ts",

--- a/nodejs/src/__tests__/usage.test.js
+++ b/nodejs/src/__tests__/usage.test.js
@@ -36,6 +36,22 @@ describe('sign', () => {
       }
     });
   });
+
+  it("should throw if using a non-string body", () => {
+    const idempotencyKey = "idemp-2076717c-9005-4811-a321-9e0787fa0382";
+    const path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
+
+    const fn = () => sign({
+      kid: KID,
+      privateKeyPem: PRIVATE_KEY,
+      method: "post",
+      path,
+      headers: { "Idempotency-Key": idempotencyKey },
+      body: { "currency": "GBP", "max_amount_in_minor": 5000000 }, // wrong
+    });
+
+    expect(fn).toThrow(new Error("Invalid body 'object' type must be a string"));
+  });
 });
 
 describe("verify", () => {

--- a/nodejs/src/lib.ts
+++ b/nodejs/src/lib.ts
@@ -37,6 +37,9 @@ const buildV2SigningPayload = ({
   if (!path.startsWith('/')) {
     throw new Error(`Invalid path \"${path}\" must start with '/'`);
   }
+  if (!(typeof body === 'string' || (body as any) instanceof String)) {
+    throw new Error(`Invalid body '${typeof body}' type must be a string`);
+  }
 
   let payload = `${method} ${path}\n`;
 


### PR DESCRIPTION
Add validation that `body` is a string. This can otherwise silently produce a useless signature.

Resolves #84