### PR TITLE
PHP-46: Signer improvements & fixes

### DIFF
--- a/php/CHANGELOG.md
+++ b/php/CHANGELOG.md
@@ -1,25 +1,45 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.1.0] - 2022-05-05
+## [0.1.1] - 2022-08-17
+
 ### Added
+
+- Accept any header casing
+- Handle trailing / in paths more gracefully #80
+
+### Changed
+
+- Improve documentation
+- Fix workflow testing failing due to new Pest release
+
+## [0.1.0] - 2022-05-05
+
+### Added
+
 - Support for verifying a signature using JSON keys.
 - Support for verifying a signature using `Jose\Component\Core\JWK` keys.
 
 ### Changed
-- Methods that enable signature verification using PEM or PEM files can now receive multiple strings or paths (i.e multiple keys).
-The signature is verified if at least one key verification succeeds.
+
+- Methods that enable signature verification using PEM or PEM files can now receive multiple strings or paths (i.e
+  multiple keys). The signature is verified if at least one key verification succeeds.
 
 ## [0.0.2] - 2022-01-05
+
 ### Changed
+
 - Excluded build/test files when publishing on packagist.
 
 ## [0.0.1] - 2021-12-09
+
 ### Added
+
 - Support for signing using a PEM string, PEM file, PEM base64 string or `Jose\Component\Core\JWK` key.
 - Support for verifying a signature using a PEM string, PEM file, PEM base64 string or `Jose\Component\Core\JWK` key.

--- a/php/README.md
+++ b/php/README.md
@@ -73,7 +73,7 @@ Then you can use it to verify the signature you receive in your webhook under th
 ```php
 $verifier
     ->path('/path') // Should be your webhook path, for example $_SERVER['REQUEST_URI']
-    ->headers($headers) // All headers you receive. The header keys should be lowercased.
+    ->headers($headers) // All headers you receive. Header names can be in any casing.
     ->body('stringified request body'); // For example file_get_contents('php://input');
 
 try {

--- a/php/README.md
+++ b/php/README.md
@@ -1,8 +1,10 @@
 # TrueLayer/Signing
-PHP library to produce & verify TrueLayer API request signatures.
-If you want to know more about how TrueLayer's signatures work, see [this documentation](./../request-signing-v2.md) for an explanation.
+
+PHP library to produce & verify TrueLayer API request signatures. If you want to know more about how TrueLayer's
+signatures work, see [this documentation](./../request-signing-v2.md) for an explanation.
 
 ## Installation
+
 Require using composer:
 
 ```shell
@@ -12,77 +14,71 @@ $ composer require truelayer/signing
 ## Usage
 
 ### Signing
-```php
-<?php
-declare(strict_types=1);
 
+First, create a Signer instance, using one of the following methods:
+
+```php
 use TrueLayer\Signing\Signer;
 
 $signer = Signer::signWithPemFile('kid-value', '/path/to/privatekey');
-$signer->method('POST')
-    ->path('/path')
-    ->header('Idempotency-Key', 'my-key')
-    ->body('stringified request body');
-    
-$signature = $signer->sign();
+$signer = Signer::signWithPem('kid-value', $pemContents);
+$signer = Signer::signWithPemBase64('kid-value', $pemContentsBase64Encoded);
+$signer = Signer::signWithKey('kid-value', new \Jose\Component\Core\JWK());
 ```
 
-You can also sign a PSR-7 request which will automatically compile the signature and add it to the `Tl-Signature` header.
-```php
-<?php
-declare(strict_types=1);
+Then you can use it to create signatures:
 
+```php
 use TrueLayer\Signing\Signer;
 
-$signer = Signer::signWithPemFile('kid-value', '/path/to/privatekey');
+$signature = $signer->method('POST')
+    ->path('/path') // The api path
+    ->header('Idempotency-Key', 'my-key') // The idempotency key you must send with your request
+    ->body('stringified request body')
+    ->sign();    
+```
+
+You can also sign a PSR-7 request which will automatically compile the signature and add it to the `Tl-Signature`
+header.
+
+```php
+use TrueLayer\Signing\Signer;
+
 $request = $signer->addSignatureHeader($request)
 ```
 
 ### Verifying
-You can use the library to verify signatures as well.
+
+First, retrieve the public keys:
+
+- for sandbox: https://webhooks.truelayer-sandbox.com/.well-known/jwks
+- for production: https://webhooks.truelayer.com/.well-known/jwks
+
+Example using the [Guzzle](https://docs.guzzlephp.org/en/stable/) library:
+
 ```php
-<?php
-declare(strict_types=1);
-
-use TrueLayer\Signing\Exceptions\InvalidSignatureException;
 use TrueLayer\Signing\Verifier;
+use GuzzleHttp\Client;
 
-$verifier = Verifier::verifyWithPemFile('/path/to/publickey');
-$verifier->method('POST')
-    ->path('/path')
-    ->headers([
-        'Idempotency-Key' => 'my-key',
-        'Correlation-Id'  => 'my-correlation',
-    ])
-    ->requireHeaders([
-        'User-Agent',
-    ])
-    ->body('stringified request body');
+// Note: you should add error handling as appropriate
+$httpClient = new Client();
+$response = $httpClient->get('https://webhooks.truelayer-sandbox.com/.well-known/jwks')->getBody()->getContents();
+$keys = json_decode($response, true)['keys'];
 
-try {
-    $verifier->verify('this is a fake signature');
-} catch (InvalidSignatureException $e) {
-    throw $e;
-}
+$verifier = Verifier::verifyWithJsonKeys(...$keys); // Note the spread operator, it's important.
 ```
 
-### Loading keys
-Depending on your use case, the library allows various ways of instantiating the Signer and the Verifier.
+Then you can use it to verify the signature you receive in your webhook under the `tl-signature` header:
+
 ```php
-<?php
-declare(strict_types=1);
+$verifier
+    ->path('/path') // Should be your webhook path, for example $_SERVER['REQUEST_URI']
+    ->headers($headers) // All headers you receive. The header keys should be lowercased.
+    ->body('stringified request body'); // For example file_get_contents('php://input');
 
-use TrueLayer\Signing\Signer;
-use TrueLayer\Signing\Verifier;
-
-Signer::signWithPemFile('kid-value', '/path/to/privatekey', 'optional-passphrase');
-Signer::signWithPem('kid-value', 'privatekey-pem-text', 'optional-passphrase');
-Signer::signWithPemBase64('kid-value', 'base64-privatekey-pem-text', 'optional-passphrase');
-Signer::signWithKey('kid-value', new \Jose\Component\Core\JWK());
-
-Verifier::verifyWithPemFile('path/to/publickey');
-Verifier::verifyWithPem('publickey-pem-text');
-Verifier::verifyWithPemBase64('base64-publickey-pem-text');
-Verifier::verifyWithJsonKeys(...$arrayOfMultipleJsonKeys);
-Verifier::verifyWithKey(new \Jose\Component\Core\JWK());
+try {
+    $verifier->verify($headers['tl-signature']);
+} catch (InvalidSignatureException $e) {
+    throw $e; // Handle invalid signature. You should not use this request's data.
+}
 ```

--- a/php/composer.json
+++ b/php/composer.json
@@ -43,5 +43,20 @@
         "roave/security-advisories": "dev-latest",
         "friendsofphp/php-cs-fixer": "^3.3",
         "mockery/mockery": "^1.4"
+    },
+    "scripts": {
+        "analyse": "vendor/bin/phpstan analyse --memory-limit=-1",
+        "tests": "vendor/bin/pest",
+        "cs-fix": "vendor/bin/php-cs-fixer fix",
+        "checks": [
+            "@analyse",
+            "@tests",
+            "@cs-fix"
+        ]
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     }
 }

--- a/php/src/Contracts/Jws.php
+++ b/php/src/Contracts/Jws.php
@@ -43,9 +43,10 @@ interface Jws
     public function headers(array $headers): self;
 
     /**
-     * @param string[] $orderOfHeaderKeys
+     * @param string[] $tlHeaders
+     * @param bool     $withTrailingSlash
      *
      * @return string
      */
-    public function buildPayload(array $orderOfHeaderKeys): string;
+    public function buildPayload(array $tlHeaders, bool $withTrailingSlash = false): string;
 }

--- a/php/src/Contracts/Verifier.php
+++ b/php/src/Contracts/Verifier.php
@@ -33,24 +33,27 @@ interface Verifier extends Jws
     /**
      * @param string ...$pems
      *
-     * @return static
      * @throws InvalidArgumentException
+     *
+     * @return static
      */
     public static function verifyWithPem(string ...$pems): self;
 
     /**
      * @param string ...$pemsBase64
      *
-     * @return static
      * @throws InvalidArgumentException
+     *
+     * @return static
      */
     public static function verifyWithPemBase64(string ...$pemsBase64): self;
 
     /**
      * @param string ...$paths
      *
-     * @return static
      * @throws InvalidArgumentException
+     *
+     * @return static
      */
     public static function verifyWithPemFile(string ...$paths): self;
 

--- a/php/tests/SignerTest.php
+++ b/php/tests/SignerTest.php
@@ -7,7 +7,7 @@ use TrueLayer\Signing\Exceptions\RequestPathNotFoundException;
 use TrueLayer\Signing\Signer;
 use TrueLayer\Signing\Tests\MockData;
 
-it('should produce a signature', function () {
+\it('should produce a signature', function () {
     $keys = MockData::generateKeyPair();
     $signer = Signer::signWithKey(Uuid::uuid4()->toString(), $keys['private']);
 
@@ -16,13 +16,13 @@ it('should produce a signature', function () {
     \expect($signer->sign())->toBeString();
 });
 
-it('should throw when the request path is not set', function () {
+\it('should throw when the request path is not set', function () {
     $keys = MockData::generateKeyPair();
     $signer = Signer::signWithKey(Uuid::uuid4()->toString(), $keys['private']);
     $signer->sign();
 })->throws(RequestPathNotFoundException::class);
 
-it('should allow signing a request with no headers', function () {
+\it('should allow signing a request with no headers', function () {
     $keys = MockData::generateKeyPair();
     $signer = Signer::signWithKey(Uuid::uuid4()->toString(), $keys['private']);
 
@@ -32,10 +32,10 @@ it('should allow signing a request with no headers', function () {
     \expect($signer->sign())->not->toThrow(Exception::class);
 });
 
-/**
+/*
  * @throws RequestPathNotFoundException
  */
-it( 'should allow signing classes implementing PSR7 interfaces', function () {
+\it('should allow signing classes implementing PSR7 interfaces', function () {
     $keys = MockData::generateKeyPair();
     $kid = Uuid::uuid4()->toString();
     $path = '/test';

--- a/php/tests/UtilTest.php
+++ b/php/tests/UtilTest.php
@@ -1,6 +1,6 @@
 <?php
 
-it('should normalise associative arrays of headers', function () {
+\it('should normalise associative arrays of headers', function () {
     $headers = [
         'X-Header' => 'foo',
         'Another-Head' => 'bAr',
@@ -8,14 +8,14 @@ it('should normalise associative arrays of headers', function () {
 
     $normalised = \TrueLayer\Signing\Util::normaliseHeaders($headers);
 
-    expect($normalised)->toBeArray();
-    expect($normalised)->toEqual([
+    \expect($normalised)->toBeArray();
+    \expect($normalised)->toEqual([
         'Another-Head' => 'bAr',
         'X-Header' => 'foo',
     ]);
 });
 
-it('should normalise arrays of header keys', function () {
+\it('should normalise arrays of header keys', function () {
     $headers = [
         'X-Header',
         'Foo-Header',
@@ -24,8 +24,8 @@ it('should normalise arrays of header keys', function () {
 
     $normalised = \TrueLayer\Signing\Util::normaliseHeaderKeys($headers);
 
-    expect($normalised)->toBeArray();
-    expect($normalised)->toEqual([
+    \expect($normalised)->toBeArray();
+    \expect($normalised)->toEqual([
         'Another-Header',
         'Foo-Header',
         'X-Header',


### PR DESCRIPTION
- Improve documentation especially for verifying webhook signatures
- Accept any header casing
- #80 option 2
- Fix workflow testing failing due to new Pest release