### PR TITLE
fix: [PAYG-1295] Improve error handling when parsing invalid signature

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -19,16 +19,13 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '5.0.x'
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '3.1.x'
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '2.2.x'
+        dotnet-version: '5.0.x'
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '2.2.x'
     - run: cd csharp && dotnet build && dotnet test
 
   examples:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -19,6 +19,9 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
+        dotnet-version: '6.0.x'
+    - uses: actions/setup-dotnet@v1
+      with:
         dotnet-version: '5.0.x'
     - uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -19,13 +19,16 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '2.2.x'
+        dotnet-version: '6.0.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '5.0.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '3.1.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '2.2.x'
     - run: cd csharp && dotnet build && dotnet test
 
   examples:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -23,12 +23,12 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.x'
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '2.2.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '3.1.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '2.2.x'
     - run: cd csharp && dotnet build && dotnet test
 
   examples:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -19,16 +19,13 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '5.0.x'
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '3.1.x'
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '2.2.x'
+        dotnet-version: '3.1.x'
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '2.2.x'
     - run: cd csharp && dotnet build && dotnet test
 
   examples:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v3
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'

--- a/.github/workflows/java7.yml
+++ b/.github/workflows/java7.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v3
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'

--- a/.github/workflows/java7.yml
+++ b/.github/workflows/java7.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        java: [ 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ]
+        java: [ 8 ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch

--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.13
+* Improves error handling when parsing and invalid signature.
+
 ## 0.1.12
 * Verifier `RequireHeader` now matches case insensitively.
 

--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -65,9 +65,15 @@ namespace TrueLayer.Signing
         /// <exception cref="SignatureException">Signature is invalid</exception>
         public static string ExtractKid(string tlSignature)
         {
-            var jwsHeaders = SignatureException.Try(
-                () => Jose.JWT.Headers(tlSignature),
-                "Failed to parse JWS's header as JSON");
+            IDictionary<string, object>? jwsHeaders;
+            try
+            {
+                jwsHeaders = Jose.JWT.Headers(tlSignature);
+            }
+            catch (Exception e)
+            {
+                throw new SignatureException($"Failed to parse JWS: {e.Message}", e);
+            }
             var kid = jwsHeaders.GetString("kid");
             if (kid == null)
             {
@@ -83,9 +89,15 @@ namespace TrueLayer.Signing
         /// <exception cref="SignatureException">Signature is invalid</exception>
         public static string ExtractJku(string tlSignature)
         {
-            var jwsHeaders = SignatureException.Try(
-                () => Jose.JWT.Headers(tlSignature),
-                "Failed to parse JWS's header as JSON");
+            IDictionary<string, object>? jwsHeaders;
+            try
+            {
+                jwsHeaders = Jose.JWT.Headers(tlSignature);
+            }
+            catch (Exception e)
+            {
+                throw new SignatureException($"Failed to parse JWS: {e.Message}", e);
+            }
             var jku = jwsHeaders.GetString("jku");
             if (jku == null)
             {
@@ -208,10 +220,15 @@ namespace TrueLayer.Signing
         /// <exception cref="SignatureException">Signature is invalid</exception>
         public void Verify(string tlSignature)
         {
-            var jwsHeaders = SignatureException.Try(
-                () => Jose.JWT.Headers(tlSignature),
-                "Failed to parse JWS's header as JSON");
-
+            IDictionary<string, object>? jwsHeaders;
+            try
+            {
+                jwsHeaders = Jose.JWT.Headers(tlSignature);
+            }
+            catch (Exception e)
+            {
+                throw new SignatureException($"Failed to parse JWS: {e.Message}", e);
+            }
             if (jwks is Jwks jwkeys)
             {
                 // initialize public key using jwks data

--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -65,7 +65,10 @@ namespace TrueLayer.Signing
         /// <exception cref="SignatureException">Signature is invalid</exception>
         public static string ExtractKid(string tlSignature)
         {
-            var kid = Jose.JWT.Headers(tlSignature).GetString("kid");
+            var jwsHeaders = SignatureException.Try(
+                () => Jose.JWT.Headers(tlSignature),
+                "Failed to parse JWS's header as JSON");
+            var kid = jwsHeaders.GetString("kid");
             if (kid == null)
             {
                 throw new SignatureException("missing kid");
@@ -80,7 +83,10 @@ namespace TrueLayer.Signing
         /// <exception cref="SignatureException">Signature is invalid</exception>
         public static string ExtractJku(string tlSignature)
         {
-            var jku = Jose.JWT.Headers(tlSignature).GetString("jku");
+            var jwsHeaders = SignatureException.Try(
+                () => Jose.JWT.Headers(tlSignature),
+                "Failed to parse JWS's header as JSON");
+            var jku = jwsHeaders.GetString("jku");
             if (jku == null)
             {
                 throw new SignatureException("missing jku");
@@ -202,7 +208,9 @@ namespace TrueLayer.Signing
         /// <exception cref="SignatureException">Signature is invalid</exception>
         public void Verify(string tlSignature)
         {
-            var jwsHeaders = SignatureException.Try(() => Jose.JWT.Headers(tlSignature));
+            var jwsHeaders = SignatureException.Try(
+                () => Jose.JWT.Headers(tlSignature),
+                "Failed to parse JWS's header as JSON");
 
             if (jwks is Jwks jwkeys)
             {

--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -67,7 +67,7 @@ namespace TrueLayer.Signing
         {
             var jwsHeaders = SignatureException.Try(
                 () => Jose.JWT.Headers(tlSignature),
-                "Failed to parse JWS's header as JSON");
+                "Failed to parse JWS as JSON");
             var kid = jwsHeaders.GetString("kid");
             if (kid == null)
             {
@@ -85,7 +85,7 @@ namespace TrueLayer.Signing
         {
             var jwsHeaders = SignatureException.Try(
                 () => Jose.JWT.Headers(tlSignature),
-                "Failed to parse JWS's header as JSON");
+                "Failed to parse JWS as JSON");
             var jku = jwsHeaders.GetString("jku");
             if (jku == null)
             {
@@ -210,7 +210,7 @@ namespace TrueLayer.Signing
         {
             var jwsHeaders = SignatureException.Try(
                 () => Jose.JWT.Headers(tlSignature),
-                "Failed to parse JWS's header as JSON");
+                "Failed to parse JWS as JSON");
 
             if (jwks is Jwks jwkeys)
             {

--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -70,7 +70,7 @@ namespace TrueLayer.Signing
             {
                 jwsHeaders = Jose.JWT.Headers(tlSignature);
             }
-            catch (JsonException e)
+            catch (Exception e)
             {
                 throw new SignatureException($"Failed to parse JWS: {e.Message}", e);
             }
@@ -94,7 +94,7 @@ namespace TrueLayer.Signing
             {
                 jwsHeaders = Jose.JWT.Headers(tlSignature);
             }
-            catch (JsonException e)
+            catch (Exception e)
             {
                 throw new SignatureException($"Failed to parse JWS: {e.Message}", e);
             }
@@ -225,7 +225,7 @@ namespace TrueLayer.Signing
             {
                 jwsHeaders = Jose.JWT.Headers(tlSignature);
             }
-            catch (JsonException e)
+            catch (Exception e)
             {
                 throw new SignatureException($"Failed to parse JWS: {e.Message}", e);
             }

--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -67,7 +67,7 @@ namespace TrueLayer.Signing
         {
             var jwsHeaders = SignatureException.Try(
                 () => Jose.JWT.Headers(tlSignature),
-                "Failed to parse JWS as JSON");
+                "Failed to parse JWS's header as JSON");
             var kid = jwsHeaders.GetString("kid");
             if (kid == null)
             {
@@ -85,7 +85,7 @@ namespace TrueLayer.Signing
         {
             var jwsHeaders = SignatureException.Try(
                 () => Jose.JWT.Headers(tlSignature),
-                "Failed to parse JWS as JSON");
+                "Failed to parse JWS's header as JSON");
             var jku = jwsHeaders.GetString("jku");
             if (jku == null)
             {
@@ -210,7 +210,7 @@ namespace TrueLayer.Signing
         {
             var jwsHeaders = SignatureException.Try(
                 () => Jose.JWT.Headers(tlSignature),
-                "Failed to parse JWS as JSON");
+                "Failed to parse JWS's header as JSON");
 
             if (jwks is Jwks jwkeys)
             {

--- a/csharp/src/Verifier.cs
+++ b/csharp/src/Verifier.cs
@@ -70,7 +70,7 @@ namespace TrueLayer.Signing
             {
                 jwsHeaders = Jose.JWT.Headers(tlSignature);
             }
-            catch (Exception e)
+            catch (JsonException e)
             {
                 throw new SignatureException($"Failed to parse JWS: {e.Message}", e);
             }
@@ -94,7 +94,7 @@ namespace TrueLayer.Signing
             {
                 jwsHeaders = Jose.JWT.Headers(tlSignature);
             }
-            catch (Exception e)
+            catch (JsonException e)
             {
                 throw new SignatureException($"Failed to parse JWS: {e.Message}", e);
             }
@@ -225,7 +225,7 @@ namespace TrueLayer.Signing
             {
                 jwsHeaders = Jose.JWT.Headers(tlSignature);
             }
-            catch (Exception e)
+            catch (JsonException e)
             {
                 throw new SignatureException($"Failed to parse JWS: {e.Message}", e);
             }

--- a/csharp/src/truelayer-signing.csproj
+++ b/csharp/src/truelayer-signing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageVersion>0.1.12</PackageVersion>
+    <PackageVersion>0.1.13</PackageVersion>
     <TargetFrameworks>net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Nullable>enable</Nullable>

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -317,6 +317,16 @@ namespace TrueLayer.Signing.Tests
         }
 
         [Fact]
+        public void VerifierExtractKid_FromInvalidSignature_ShouldThrowException()
+        {
+            Action action = () => { Verifier.ExtractKid("an-invalid-signature"); };
+            action
+                .Should()
+                .Throw<SignatureException>()
+                .WithMessage("Failed to parse JWS's header as JSON");
+        }
+
+        [Fact]
         public void Verifier_ExtractJku()
         {
             var tlSignature = File.ReadAllText(TestResourcePath("webhook-signature.txt")).Trim();

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -323,7 +323,7 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
-                .WithMessage("Failed to parse JWS's header as JSON");
+                .WithMessage("Failed to parse JWS: 'j' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.");
         }
 
         [Fact]
@@ -340,7 +340,7 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
-                .WithMessage("Failed to parse JWS's header as JSON");
+                .WithMessage("Failed to parse JWS: 'j' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.");
         }
 
         [Fact]
@@ -380,7 +380,7 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
-                .WithMessage("Failed to parse JWS's header as JSON");
+                .WithMessage("Failed to parse JWS: 'j' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.");
         }
 
         public sealed class TestCase

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -336,7 +336,7 @@ namespace TrueLayer.Signing.Tests
         [Fact]
         public void VerifierExtractJku_FromInvalidSignature_ShouldThrowSignatureException()
         {
-            Action action = () => { Verifier.ExtractJku("an-invalid-signature"); };
+            Action action = () => { Verifier.ExtractJku("an-invalid..signature"); };
             action
                 .Should()
                 .Throw<SignatureException>()
@@ -375,7 +375,7 @@ namespace TrueLayer.Signing.Tests
                 .Method("POST")
                 .Path("/bar")
                 .Body("{}")
-                .Verify("an-invalid-signature");
+                .Verify("an-invalid..signature");
 
             action
                 .Should()

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -323,6 +323,7 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
+// exception message changed between version 2.2 and 3.1 due to a migration from Newtonsoft.Json (Json.NET) to System.Text.Json
 #if (NETCOREAPP3_1 || NETCOREAPP3_1_OR_GREATER)
                 .WithMessage("Failed to parse JWS: 'j' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.");
 #else
@@ -344,7 +345,12 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
+// exception message changed between version 2.2 and 3.1 due to a migration from Newtonsoft.Json (Json.NET) to System.Text.Json
+#if (NETCOREAPP3_1 || NETCOREAPP3_1_OR_GREATER)
                 .WithMessage("Failed to parse JWS: 'j' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.");
+#else
+                .WithMessage("Failed to parse JWS: Unexpected character encountered while parsing value: j. Path '', line 0, position 0.");
+#endif
         }
 
         [Fact]
@@ -384,7 +390,12 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
+// exception message changed between version 2.2 and 3.1 due to a migration from Newtonsoft.Json (Json.NET) to System.Text.Json
+#if (NETCOREAPP3_1 || NETCOREAPP3_1_OR_GREATER)
                 .WithMessage("Failed to parse JWS: 'j' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.");
+#else
+                .WithMessage("Failed to parse JWS: Unexpected character encountered while parsing value: j. Path '', line 0, position 0.");
+#endif
         }
 
         public sealed class TestCase

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -323,10 +323,10 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
-#if (NETSTANDARD2_0)
-                .WithMessage("Failed to parse JWS: Failed to parse JWS: Unexpected character encountered while parsing value: j. Path '', line 0, position 0.");
-#else
+#if (NETCOREAPP3_1 || NETCOREAPP3_1_OR_GREATER)
                 .WithMessage("Failed to parse JWS: 'j' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.");
+#else
+                .WithMessage("Failed to parse JWS: Failed to parse JWS: Unexpected character encountered while parsing value: j. Path '', line 0, position 0.");
 #endif
         }
 

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -323,7 +323,11 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
+#if (NETSTANDARD2_0)
+                .WithMessage("Failed to parse JWS: Failed to parse JWS: Unexpected character encountered while parsing value: j. Path '', line 0, position 0.");
+#else
                 .WithMessage("Failed to parse JWS: 'j' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.");
+#endif
         }
 
         [Fact]

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -319,11 +319,11 @@ namespace TrueLayer.Signing.Tests
         [Fact]
         public void VerifierExtractKid_FromInvalidSignature_ShouldThrowSignatureException()
         {
-            Action action = () => { Verifier.ExtractKid("an-invalid-signature"); };
+            Action action = () => { Verifier.ExtractKid("an-invalid..signature"); };
             action
                 .Should()
                 .Throw<SignatureException>()
-                .WithMessage("Failed to parse JWS as JSON");
+                .WithMessage("Failed to parse JWS's header as JSON");
         }
 
         [Fact]
@@ -340,7 +340,7 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
-                .WithMessage("Failed to parse JWS as JSON");
+                .WithMessage("Failed to parse JWS's header as JSON");
         }
 
         [Fact]
@@ -380,7 +380,7 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
-                .WithMessage("Failed to parse JWS as JSON");
+                .WithMessage("Failed to parse JWS's header as JSON");
         }
 
         public sealed class TestCase

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -326,7 +326,7 @@ namespace TrueLayer.Signing.Tests
 #if (NETCOREAPP3_1 || NETCOREAPP3_1_OR_GREATER)
                 .WithMessage("Failed to parse JWS: 'j' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.");
 #else
-                .WithMessage("Failed to parse JWS: Failed to parse JWS: Unexpected character encountered while parsing value: j. Path '', line 0, position 0.");
+                .WithMessage("Failed to parse JWS: Unexpected character encountered while parsing value: j. Path '', line 0, position 0.");
 #endif
         }
 

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -317,7 +317,7 @@ namespace TrueLayer.Signing.Tests
         }
 
         [Fact]
-        public void VerifierExtractKid_FromInvalidSignature_ShouldThrowException()
+        public void VerifierExtractKid_FromInvalidSignature_ShouldThrowSignatureException()
         {
             Action action = () => { Verifier.ExtractKid("an-invalid-signature"); };
             action
@@ -331,6 +331,16 @@ namespace TrueLayer.Signing.Tests
         {
             var tlSignature = File.ReadAllText(TestResourcePath("webhook-signature.txt")).Trim();
             Verifier.ExtractJku(tlSignature).Should().Be("https://webhooks.truelayer.com/.well-known/jwks");
+        }
+
+        [Fact]
+        public void VerifierExtractJku_FromInvalidSignature_ShouldThrowSignatureException()
+        {
+            Action action = () => { Verifier.ExtractJku("an-invalid-signature"); };
+            action
+                .Should()
+                .Throw<SignatureException>()
+                .WithMessage("Failed to parse JWS's header as JSON");
         }
 
         [Fact]
@@ -356,6 +366,21 @@ namespace TrueLayer.Signing.Tests
                 .Verify(tlSignature);
 
             verify.Should().Throw<SignatureException>();
+        }
+
+        [Fact]
+        public void VerifierVerify_InvalidSignature_ShouldThrowSignatureException()
+        {
+            Action action = () => Verifier.VerifyWithPem(PublicKey)
+                .Method("POST")
+                .Path("/bar")
+                .Body("{}")
+                .Verify("an-invalid-signature");
+
+            action
+                .Should()
+                .Throw<SignatureException>()
+                .WithMessage("Failed to parse JWS's header as JSON");
         }
 
         public sealed class TestCase

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -323,7 +323,7 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
-                .WithMessage("Failed to parse JWS's header as JSON");
+                .WithMessage("Failed to parse JWS as JSON");
         }
 
         [Fact]
@@ -340,7 +340,7 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
-                .WithMessage("Failed to parse JWS's header as JSON");
+                .WithMessage("Failed to parse JWS as JSON");
         }
 
         [Fact]
@@ -380,7 +380,7 @@ namespace TrueLayer.Signing.Tests
             action
                 .Should()
                 .Throw<SignatureException>()
-                .WithMessage("Failed to parse JWS's header as JSON");
+                .WithMessage("Failed to parse JWS as JSON");
         }
 
         public sealed class TestCase

--- a/csharp/test/truelayer-signing.test.csproj
+++ b/csharp/test/truelayer-signing.test.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;net5.0</TargetFrameworks>
+<!--    <TargetFrameworks>net6.0</TargetFrameworks>-->
+<!--      <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;net5.0</TargetFrameworks>-->
+      <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>8</LangVersion>
     <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8618</WarningsAsErrors>

--- a/csharp/test/truelayer-signing.test.csproj
+++ b/csharp/test/truelayer-signing.test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;net5.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>8</LangVersion>
     <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8618</WarningsAsErrors>

--- a/csharp/test/truelayer-signing.test.csproj
+++ b/csharp/test/truelayer-signing.test.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-<!--    <TargetFrameworks>net6.0</TargetFrameworks>-->
 <!--      <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;net5.0</TargetFrameworks>-->
-      <TargetFramework>net6.0</TargetFramework>
+      <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+<!--      <TargetFramework>net6.0</TargetFramework>-->
     <Nullable>enable</Nullable>
     <LangVersion>8</LangVersion>
     <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8618</WarningsAsErrors>

--- a/csharp/test/truelayer-signing.test.csproj
+++ b/csharp/test/truelayer-signing.test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>8</LangVersion>
     <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8618</WarningsAsErrors>

--- a/csharp/test/truelayer-signing.test.csproj
+++ b/csharp/test/truelayer-signing.test.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-<!--      <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;net5.0</TargetFrameworks>-->
-      <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
-<!--      <TargetFramework>net6.0</TargetFramework>-->
+    <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;net5.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>8</LangVersion>
     <WarningsAsErrors>CS8600;CS8602;CS8603;CS8604;CS8618</WarningsAsErrors>

--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.8
+* Improves error handling when parsing and invalid signature.
+
 ## 0.1.7
 * When verifying permit signed/verified path single trailing slash mismatches.
 

--- a/go/tlsigning_test.go
+++ b/go/tlsigning_test.go
@@ -102,6 +102,27 @@ func TestVerifyStaticSignature(t *testing.T) {
 	assert.Nilf(err, "signature verification should not fail: %v", err)
 }
 
+func TestVerify_WithInvalidSignature_ShouldReturnError(t *testing.T) {
+	assert := assert.New(t)
+
+	_, publicKeyBytes := getTestKeys(assert)
+
+	body := []byte("{\"currency\":\"GBP\",\"max_amount_in_minor\":5000000,\"name\":\"Foo???\"}")
+	idempotencyKey := []byte("idemp-2076717c-9005-4811-a321-9e0787fa0382")
+	path := "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping"
+
+	err := VerifyWithPem(publicKeyBytes).
+		Method("POST").
+		Path(path).
+		Header("X-Whatever-2", []byte("t2345d")).
+		Header("Idempotency-Key", idempotencyKey).
+		Body(body).
+		Verify("an-invalid..signature")
+	assert.NotNilf(err, "signature verification should not fail: %v", err)
+	assert.EqualError(err, "jws signing/verification failed: signature parsing failed: signature base64 decode failed: illegal base64 data at input byte 8")
+	assert.ErrorAs(&errors.JwsError{}, &err, "error should be a JwsError")
+}
+
 func TestSignatureMethodMismatch(t *testing.T) {
 	assert := assert.New(t)
 

--- a/go/tlsigning_test.go
+++ b/go/tlsigning_test.go
@@ -102,7 +102,7 @@ func TestVerifyStaticSignature(t *testing.T) {
 	assert.Nilf(err, "signature verification should not fail: %v", err)
 }
 
-func TestVerify_WithInvalidSignature_ShouldReturnError(t *testing.T) {
+func TestVerifyWithInvalidSignatureShouldReturnError(t *testing.T) {
 	assert := assert.New(t)
 
 	_, publicKeyBytes := getTestKeys(assert)
@@ -118,6 +118,7 @@ func TestVerify_WithInvalidSignature_ShouldReturnError(t *testing.T) {
 		Header("Idempotency-Key", idempotencyKey).
 		Body(body).
 		Verify("an-invalid..signature")
+
 	assert.NotNilf(err, "signature verification should not fail: %v", err)
 	assert.EqualError(err, "jws signing/verification failed: signature parsing failed: signature base64 decode failed: illegal base64 data at input byte 8")
 	assert.ErrorAs(&errors.JwsError{}, &err, "error should be a JwsError")

--- a/java/CHANGELOG.md
+++ b/java/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.5
+* Improves error handling when parsing and invalid signature.
+
 ## 0.2.4
 * Update dependencies.
 

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -1,6 +1,6 @@
 # Main properties
 group=com.truelayer
-version=0.2.4
+version=0.2.5
 
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/
 sonatype_snapshot_repository_url=https://s01.oss.sonatype.org/content/repositories/snapshots/

--- a/java/lib/src/main/java/com/truelayer/signing/SignatureException.java
+++ b/java/lib/src/main/java/com/truelayer/signing/SignatureException.java
@@ -26,7 +26,7 @@ public class SignatureException extends RuntimeException {
         } catch (SignatureException e) {
             throw e;
         } catch (ParseException e) {
-            throw new SignatureException("Failed to parse JWS as JSON", e);
+            throw new SignatureException("Failed to parse JWS's header as JSON", e);
         } catch (Exception e) {
             throw new SignatureException(e.getMessage(), e);
         }

--- a/java/lib/src/main/java/com/truelayer/signing/SignatureException.java
+++ b/java/lib/src/main/java/com/truelayer/signing/SignatureException.java
@@ -1,5 +1,7 @@
 package com.truelayer.signing;
 
+import java.text.ParseException;
+
 /**
  * Sign/verification error
  */
@@ -23,6 +25,8 @@ public class SignatureException extends RuntimeException {
             return f.get();
         } catch (SignatureException e) {
             throw e;
+        } catch (ParseException e) {
+            throw new SignatureException("Failed to parse JWS as JSON", e);
         } catch (Exception e) {
             throw new SignatureException(e.getMessage(), e);
         }

--- a/java/lib/src/main/java/com/truelayer/signing/SignatureException.java
+++ b/java/lib/src/main/java/com/truelayer/signing/SignatureException.java
@@ -26,7 +26,7 @@ public class SignatureException extends RuntimeException {
         } catch (SignatureException e) {
             throw e;
         } catch (ParseException e) {
-            throw new SignatureException("Failed to parse JWS's header as JSON", e);
+            throw new SignatureException("Failed to parse JWS: " + e.getMessage(), e);
         } catch (Exception e) {
             throw new SignatureException(e.getMessage(), e);
         }

--- a/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
+++ b/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
@@ -271,7 +271,7 @@ public class UsageTest {
 
         SignatureException invalidSignatureException = assertThrows(SignatureException.class, () -> verifier.verify(signature));
 
-        assertEquals("Failed to parse JWS's header as JSON", invalidSignatureException.getMessage());
+        assertEquals("Failed to parse JWS: The payload Base64URL part must be empty", invalidSignatureException.getMessage());
     }
 
     @Test
@@ -290,7 +290,7 @@ public class UsageTest {
 
         SignatureException invalidSignatureException = assertThrows(SignatureException.class, () -> verifier.verify(signature));
 
-        assertEquals("Failed to parse JWS's header as JSON", invalidSignatureException.getMessage());
+        assertEquals("Failed to parse JWS: Invalid serialized unsecured/JWS/JWE object: Too many part delimiters", invalidSignatureException.getMessage());
     }
 
     @Test
@@ -376,7 +376,7 @@ public class UsageTest {
                 SignatureException.class,
                 () -> Verifier.extractJku("an-invalid..signature")
         );
-        assertEquals("Failed to parse JWS's header as JSON", e.getMessage());
+        assertEquals("Failed to parse JWS: Invalid JWS header: Invalid JSON: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $", e.getMessage());
     }
 
     @Test
@@ -415,7 +415,7 @@ public class UsageTest {
                         .body("{}")
                         .verify("an-invalid..signature")
         );
-        assertEquals("Failed to parse JWS's header as JSON", e.getMessage());
+        assertEquals("Failed to parse JWS: Invalid JSON: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $", e.getMessage());
     }
 
     @Test

--- a/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
+++ b/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
@@ -371,6 +371,15 @@ public class UsageTest {
     }
 
     @Test
+    public void verifierExtractJku_InvalidSignature_ThrowsSignatureException() {
+        Exception e = assertThrows(
+                SignatureException.class,
+                () -> Verifier.extractJku("an-invalid-signature")
+        );
+        assertEquals("Failed to parse JWS as JSON", e.getMessage());
+    }
+
+    @Test
     public void verifierJwks() {
         Verifier.verifyWithJwks(jwks)
                 .method("POST")
@@ -394,6 +403,19 @@ public class UsageTest {
         SignatureException invalidSignatureException = assertThrows(SignatureException.class, () -> verifier.verify(webhookSignature));
 
         assertEquals("invalid signature", invalidSignatureException.getMessage());
+    }
+
+    @Test
+    public void verifierVerify_InvalidSignature_ThrowsSignatureException() {
+        Exception e = assertThrows(
+                SignatureException.class,
+                () -> Verifier.verifyWithJwks(jwks)
+                        .method("POST")
+                        .path("/bar")
+                        .body("{}")
+                        .verify("an-invalid-signature")
+        );
+        assertEquals("Failed to parse JWS as JSON", e.getMessage());
     }
 
     @Test

--- a/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
+++ b/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
@@ -271,7 +271,7 @@ public class UsageTest {
 
         SignatureException invalidSignatureException = assertThrows(SignatureException.class, () -> verifier.verify(signature));
 
-        assertEquals("The payload Base64URL part must be empty", invalidSignatureException.getMessage());
+        assertEquals("Failed to parse JWS's header as JSON", invalidSignatureException.getMessage());
     }
 
     @Test
@@ -290,7 +290,7 @@ public class UsageTest {
 
         SignatureException invalidSignatureException = assertThrows(SignatureException.class, () -> verifier.verify(signature));
 
-        assertEquals("Invalid serialized unsecured/JWS/JWE object: Too many part delimiters", invalidSignatureException.getMessage());
+        assertEquals("Failed to parse JWS's header as JSON", invalidSignatureException.getMessage());
     }
 
     @Test
@@ -374,9 +374,9 @@ public class UsageTest {
     public void verifierExtractJku_InvalidSignature_ThrowsSignatureException() {
         Exception e = assertThrows(
                 SignatureException.class,
-                () -> Verifier.extractJku("an-invalid-signature")
+                () -> Verifier.extractJku("an-invalid..signature")
         );
-        assertEquals("Failed to parse JWS as JSON", e.getMessage());
+        assertEquals("Failed to parse JWS's header as JSON", e.getMessage());
     }
 
     @Test
@@ -415,7 +415,7 @@ public class UsageTest {
                         .body("{}")
                         .verify("an-invalid-signature")
         );
-        assertEquals("Failed to parse JWS as JSON", e.getMessage());
+        assertEquals("Failed to parse JWS's header as JSON", e.getMessage());
     }
 
     @Test

--- a/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
+++ b/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
@@ -413,7 +413,7 @@ public class UsageTest {
                         .method("POST")
                         .path("/bar")
                         .body("{}")
-                        .verify("an-invalid-signature")
+                        .verify("an-invalid..signature")
         );
         assertEquals("Failed to parse JWS's header as JSON", e.getMessage());
     }

--- a/java7/CHANGELOG.md
+++ b/java7/CHANGELOG.md
@@ -4,28 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.3
-* Fix base64 encoding to be url safe.
+## 0.0.5
+* Improves error handling when parsing and invalid signature.
 
-## 0.2.2
-* When verifying permit signed/verified path single trailing slash mismatches.
+## 0.0.4
 
-## 0.2.1
-* Add `path` arg validation to `Signer.sign` & `Verifier.verify` for more informative errors.
+## 0.0.3
 
-## 0.2.0
-* Move code under `com.truelayer.signing`.
-* Publish artifacts to maven central
+## 0.0.2
 
-## 0.1.3
-* Add `headers` method to `Verifier` and `Signer`.
-
-## 0.1.2
-* Add support for verifying jwks with alg: `ES512`.
-
-## 0.1.1
-* Add `Verifier.extractJku` to extract `jku` jws header from webhook signatures.
-* Add `Verifier.verifyWithJwks` to aid verifying webhook signatures.
-
-## 0.1.0
-* Added `Signer` & `Verifier` implementations.
+## 0.0.1

--- a/java7/gradle.properties
+++ b/java7/gradle.properties
@@ -1,6 +1,6 @@
 # Main properties
 group=com.truelayer
-version=0.0.4
+version=0.0.5
 
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/
 sonatype_snapshot_repository_url=https://s01.oss.sonatype.org/content/repositories/snapshots/

--- a/java7/gradle/wrapper/gradle-wrapper.properties
+++ b/java7/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java7/gradle/wrapper/gradle-wrapper.properties
+++ b/java7/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/java7/lib/src/main/java/com/truelayer/signing/Verifier.java
+++ b/java7/lib/src/main/java/com/truelayer/signing/Verifier.java
@@ -42,7 +42,7 @@ public abstract class Verifier {
         try {
             uri = JWSObject.parse(tlSignature).getHeader().getJWKURL();
         } catch (ParseException e) {
-            throw new SignatureException(e);
+            throw new SignatureException("Failed to parse JWS: " + e.getMessage(), e);
         }
         return uri.toString();
     }

--- a/java7/lib/src/main/java/com/truelayer/signing/VerifierFromJwks.java
+++ b/java7/lib/src/main/java/com/truelayer/signing/VerifierFromJwks.java
@@ -25,7 +25,7 @@ class VerifierFromJwks extends Verifier {
         try {
             jwsHeader = JWSHeader.parse(JOSEObject.split(signature)[0]);
         } catch (ParseException e) {
-            throw new SignatureException(e);
+            throw new SignatureException("Failed to parse JWS: " + e.getMessage(), e);
         }
         Map<HeaderName, String> orderedHeaders = validateSignatureHeader(jwsHeader);
 

--- a/java7/lib/src/main/java/com/truelayer/signing/VerifierFromPublicKey.java
+++ b/java7/lib/src/main/java/com/truelayer/signing/VerifierFromPublicKey.java
@@ -7,6 +7,7 @@ import com.nimbusds.jose.Payload;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
 
 import java.security.interfaces.ECPublicKey;
+import java.text.ParseException;
 import java.util.Map;
 
 class VerifierFromPublicKey extends Verifier {
@@ -22,6 +23,8 @@ class VerifierFromPublicKey extends Verifier {
         JWSHeader jwsHeader;
         try {
             jwsHeader = JWSHeader.parse(JOSEObject.split(signature)[0]);
+        } catch (ParseException e) {
+            throw new SignatureException("Failed to parse JWS: " + e.getMessage(), e);
         } catch (Exception e) {
             throw new SignatureException(e);
         }
@@ -31,6 +34,8 @@ class VerifierFromPublicKey extends Verifier {
         try {
             verifiedResult = JWSObject.parse(signature, new Payload(Utils.buildPayload(orderedHeaders, method, path, body)))
                     .verify(new ECDSAVerifier(publicKey));
+        } catch (ParseException e) {
+            throw new SignatureException("Failed to parse JWS: " + e.getMessage(), e);
         } catch (Exception e) {
             throw new SignatureException(e);
         }

--- a/java7/lib/src/test/java/com/truelayer/signing/UsageTest.java
+++ b/java7/lib/src/test/java/com/truelayer/signing/UsageTest.java
@@ -1,6 +1,5 @@
 package com.truelayer.signing;
 
-import org.hamcrest.core.StringContains;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -384,8 +383,8 @@ public class UsageTest {
     public void verifierExtractJku_InvalidSignature_ThrowsSignatureException() {
         expectedEx.expect(SignatureException.class);
         // uses two assertions (to emulate a Regex) because the message contains non UTF-16 characters
-        expectedEx.expectMessage(StringContains.containsString("Failed to parse JWS: Invalid JWS header: Invalid JSON: Unexpected token"));
-        expectedEx.expectMessage(StringContains.containsString("at position 7."));
+        expectedEx.expectMessage("Failed to parse JWS: Invalid JWS header: Invalid JSON: Unexpected token");
+        expectedEx.expectMessage("at position 7.");
         Verifier.extractJku("an-invalid..signature");
     }
 
@@ -419,8 +418,8 @@ public class UsageTest {
     public void verifierVerify_InvalidSignature_ThrowsSignatureException() {
         expectedEx.expect(SignatureException.class);
         // uses two assertions (to emulate a Regex) because the message contains non UTF-16 characters
-        expectedEx.expectMessage(StringContains.containsString("Failed to parse JWS: Invalid JSON: Unexpected token"));
-        expectedEx.expectMessage(StringContains.containsString("at position 7."));
+        expectedEx.expectMessage("Failed to parse JWS: Invalid JSON: Unexpected token");
+        expectedEx.expectMessage("at position 7.");
         Verifier.verifyWithJwks(jwks)
                 .method("POST")
                 .path("/bar")

--- a/nodejs/CHANGELOG.md
+++ b/nodejs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.6
+* Improves error handling when parsing and invalid signature.
+
 ## 0.1.5
 * When verifying permit signed/verified path single trailing slash mismatches.
 

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truelayer-signing",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Produce & verify TrueLayer API requests signatures",
   "main": "lib/lib.js",
   "types": "lib/lib.d.ts",

--- a/nodejs/src/__tests__/usage.test.ts
+++ b/nodejs/src/__tests__/usage.test.ts
@@ -437,7 +437,7 @@ describe('extractKid', () => {
 describe('extractKidInvalidSignature', () => {
   it('should throw using an invalid signature', () => {
     const fn = () => extractKid("an-invalid..signature")
-    expect(fn).toThrow(new SignatureError("Failed to parse JWS as JSON"));
+    expect(fn).toThrow(new SignatureError("Failed to parse JWS: Unexpected token j in JSON at position 0"));
   });
 });
 
@@ -452,6 +452,6 @@ describe('extractJku', () => {
 describe('extractJkuInvalidSignature', () => {
   it('should throw using an invalid signature', () => {
     const fn = () => extractJku("an-invalid..signature")
-    expect(fn).toThrow(new SignatureError("Failed to parse JWS as JSON"));
+    expect(fn).toThrow(new SignatureError("Failed to parse JWS: Unexpected token j in JSON at position 0"));
   });
 });

--- a/nodejs/src/__tests__/usage.test.ts
+++ b/nodejs/src/__tests__/usage.test.ts
@@ -434,9 +434,24 @@ describe('extractKid', () => {
   });
 });
 
+describe('extractKidInvalidSignature', () => {
+  it('should throw using an invalid signature', () => {
+    const fn = () => extractKid("an-invalid-signature")
+    expect(fn).toThrow(new SignatureError("Failed to parse JWS as JSON"));
+  });
+});
+
 describe('extractJku', () => {
   it('should produce a jku from a valid tl signature', () => {
     const jku = extractJku(WEBHOOK_SIGNATURE);
     expect(jku).toEqual('https://webhooks.truelayer.com/.well-known/jwks');
+  });
+});
+
+
+describe('extractJkuInvalidSignature', () => {
+  it('should throw using an invalid signature', () => {
+    const fn = () => extractJku("an-invalid-signature")
+    expect(fn).toThrow(new SignatureError("Failed to parse JWS as JSON"));
   });
 });

--- a/nodejs/src/__tests__/usage.test.ts
+++ b/nodejs/src/__tests__/usage.test.ts
@@ -436,8 +436,8 @@ describe('extractKid', () => {
 
 describe('extractKidInvalidSignature', () => {
   it('should throw using an invalid signature', () => {
-    const fn = () => extractKid("an-invalid-signature")
-    expect(fn).toThrow(new SignatureError("Failed to parse JWS as JSON"));
+    const fn = () => extractKid("an-invalid..signature")
+    expect(fn).toThrow(new SignatureError("Failed to parse JWS's header as JSON"));
   });
 });
 
@@ -451,7 +451,7 @@ describe('extractJku', () => {
 
 describe('extractJkuInvalidSignature', () => {
   it('should throw using an invalid signature', () => {
-    const fn = () => extractJku("an-invalid-signature")
-    expect(fn).toThrow(new SignatureError("Failed to parse JWS as JSON"));
+    const fn = () => extractJku("an-invalid..signature")
+    expect(fn).toThrow(new SignatureError("Failed to parse JWS's header as JSON"));
   });
 });

--- a/nodejs/src/__tests__/usage.test.ts
+++ b/nodejs/src/__tests__/usage.test.ts
@@ -436,8 +436,8 @@ describe('extractKid', () => {
 
 describe('extractKidInvalidSignature', () => {
   it('should throw using an invalid signature', () => {
-    const fn = () => extractKid("an-invalid..signature")
-    expect(fn).toThrow(new SignatureError("Failed to parse JWS's header as JSON"));
+    const fn = () => extractKid("an-invalid-signature")
+    expect(fn).toThrow(new SignatureError("Failed to parse JWS as JSON"));
   });
 });
 
@@ -451,7 +451,7 @@ describe('extractJku', () => {
 
 describe('extractJkuInvalidSignature', () => {
   it('should throw using an invalid signature', () => {
-    const fn = () => extractJku("an-invalid..signature")
-    expect(fn).toThrow(new SignatureError("Failed to parse JWS's header as JSON"));
+    const fn = () => extractJku("an-invalid-signature")
+    expect(fn).toThrow(new SignatureError("Failed to parse JWS as JSON"));
   });
 });

--- a/nodejs/src/__tests__/usage.test.ts
+++ b/nodejs/src/__tests__/usage.test.ts
@@ -436,7 +436,7 @@ describe('extractKid', () => {
 
 describe('extractKidInvalidSignature', () => {
   it('should throw using an invalid signature', () => {
-    const fn = () => extractKid("an-invalid-signature")
+    const fn = () => extractKid("an-invalid..signature")
     expect(fn).toThrow(new SignatureError("Failed to parse JWS as JSON"));
   });
 });
@@ -451,7 +451,7 @@ describe('extractJku', () => {
 
 describe('extractJkuInvalidSignature', () => {
   it('should throw using an invalid signature', () => {
-    const fn = () => extractJku("an-invalid-signature")
+    const fn = () => extractJku("an-invalid..signature")
     expect(fn).toThrow(new SignatureError("Failed to parse JWS as JSON"));
   });
 });

--- a/nodejs/src/lib.ts
+++ b/nodejs/src/lib.ts
@@ -98,16 +98,7 @@ const parseSignature = (signature: string) => {
   try {
     const [header, _, footer] = signature.split(".");
 
-    // TODO: extract to a function
-    let headerJson: JOSEHeader | undefined = undefined;
-    try {
-      headerJson = JSON.parse(Base64.decode(header)) as JOSEHeader;
-    } catch (error) {
-      throw new SignatureError("Failed to parse JWS as JSON");
-    }
-    if (headerJson === undefined) {
-      throw new SignatureError("something...");
-    }
+    const headerJson = parseHeader(header);
     
     SignatureError.ensure(headerJson.alg === "ES512", "unsupported header alg");
     SignatureError.ensure(
@@ -135,6 +126,19 @@ type SignArguments = {
   headers?: Record<string, string>;
   body?: string;
 };
+
+function parseHeader(header: string) {
+  let headerJson: JOSEHeader | undefined = undefined;
+  try {
+    headerJson = JSON.parse(Base64.decode(header)) as JOSEHeader;
+  } catch (error) {
+    throw new SignatureError("Failed to parse JWS's header as JSON");
+  }
+  if (headerJson === undefined) {
+    throw new SignatureError("Failed to parse JWS's header as JSON");
+  }
+  return headerJson;
+}
 
 /** Sign/verification error
  * SignatureError: SignatureError,

--- a/nodejs/src/lib.ts
+++ b/nodejs/src/lib.ts
@@ -97,8 +97,18 @@ type JOSEHeader = {
 const parseSignature = (signature: string) => {
   try {
     const [header, _, footer] = signature.split(".");
-    const headerJson = JSON.parse(Base64.decode(header)) as JOSEHeader;
 
+    // TODO: extract to a function
+    let headerJson: JOSEHeader | undefined = undefined;
+    try {
+      headerJson = JSON.parse(Base64.decode(header)) as JOSEHeader;
+    } catch (error) {
+      throw new SignatureError("Failed to parse JWS as JSON");
+    }
+    if (headerJson === undefined) {
+      throw new SignatureError("something...");
+    }
+    
     SignatureError.ensure(headerJson.alg === "ES512", "unsupported header alg");
     SignatureError.ensure(
       headerJson.tl_version === "2",

--- a/nodejs/src/lib.ts
+++ b/nodejs/src/lib.ts
@@ -98,16 +98,7 @@ const parseSignature = (signature: string) => {
   try {
     const [header, _, footer] = signature.split(".");
 
-    // TODO: extract to a function
-    let headerJson: JOSEHeader | undefined = undefined;
-    try {
-      headerJson = JSON.parse(Base64.decode(header)) as JOSEHeader;
-    } catch (error) {
-      throw new SignatureError("Failed to parse JWS as JSON");
-    }
-    if (headerJson === undefined) {
-      throw new SignatureError("something...");
-    }
+    let headerJson = parseHeader(header);
     
     SignatureError.ensure(headerJson.alg === "ES512", "unsupported header alg");
     SignatureError.ensure(
@@ -135,6 +126,19 @@ type SignArguments = {
   headers?: Record<string, string>;
   body?: string;
 };
+
+function parseHeader(header: string): JOSEHeader {
+  let headerJson: JOSEHeader | undefined = undefined;
+  try {
+    headerJson = JSON.parse(Base64.decode(header)) as JOSEHeader;
+  } catch (error) {
+    throw new SignatureError("Failed to parse JWS as JSON");
+  }
+  if (headerJson === undefined) {
+    throw new SignatureError("something...");
+  }
+  return headerJson;
+}
 
 /** Sign/verification error
  * SignatureError: SignatureError,

--- a/nodejs/src/lib.ts
+++ b/nodejs/src/lib.ts
@@ -132,10 +132,14 @@ function parseHeader(header: string): JOSEHeader {
   try {
     headerJson = JSON.parse(Base64.decode(header)) as JOSEHeader;
   } catch (error) {
-    throw new SignatureError("Failed to parse JWS as JSON");
+    if (error instanceof Error) {
+      throw new SignatureError("Failed to parse JWS: " + error.message);
+    } else {
+      throw new SignatureError("Failed to parse JWS");
+    }
   }
   if (headerJson === undefined) {
-    throw new SignatureError("Failed to parse JWS as JSON");
+    throw new SignatureError("Failed to parse JWS");
   }
   return headerJson;
 }

--- a/nodejs/src/lib.ts
+++ b/nodejs/src/lib.ts
@@ -98,7 +98,16 @@ const parseSignature = (signature: string) => {
   try {
     const [header, _, footer] = signature.split(".");
 
-    const headerJson = parseHeader(header);
+    // TODO: extract to a function
+    let headerJson: JOSEHeader | undefined = undefined;
+    try {
+      headerJson = JSON.parse(Base64.decode(header)) as JOSEHeader;
+    } catch (error) {
+      throw new SignatureError("Failed to parse JWS as JSON");
+    }
+    if (headerJson === undefined) {
+      throw new SignatureError("something...");
+    }
     
     SignatureError.ensure(headerJson.alg === "ES512", "unsupported header alg");
     SignatureError.ensure(
@@ -126,19 +135,6 @@ type SignArguments = {
   headers?: Record<string, string>;
   body?: string;
 };
-
-function parseHeader(header: string) {
-  let headerJson: JOSEHeader | undefined = undefined;
-  try {
-    headerJson = JSON.parse(Base64.decode(header)) as JOSEHeader;
-  } catch (error) {
-    throw new SignatureError("Failed to parse JWS's header as JSON");
-  }
-  if (headerJson === undefined) {
-    throw new SignatureError("Failed to parse JWS's header as JSON");
-  }
-  return headerJson;
-}
 
 /** Sign/verification error
  * SignatureError: SignatureError,

--- a/nodejs/src/lib.ts
+++ b/nodejs/src/lib.ts
@@ -135,7 +135,7 @@ function parseHeader(header: string): JOSEHeader {
     throw new SignatureError("Failed to parse JWS as JSON");
   }
   if (headerJson === undefined) {
-    throw new SignatureError("something...");
+    throw new SignatureError("Failed to parse JWS as JSON");
   }
   return headerJson;
 }

--- a/php/CHANGELOG.md
+++ b/php/CHANGELOG.md
@@ -5,8 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-* Removed license symlinks.
+## [0.1.2] - 2022-12-16
+
+### Changed
+
+- Improves error handling when parsing and invalid signature.
+- Removed license symlinks.
 
 ## [0.1.1] - 2022-08-17
 

--- a/php/src/Verifier.php
+++ b/php/src/Verifier.php
@@ -193,7 +193,7 @@ final class Verifier extends AbstractJws implements IVerifier
         try {
             $jws = $this->serializerManager->unserialize($signature);
         } catch (Exception $e) {
-            throw new InvalidSignatureException('Failed to parse JWS: ' . $e->getMessage());
+            throw new InvalidSignatureException('Failed to parse JWS: ' . $e->getMessage(), 0, $e);
         }
 
         if (!\is_null($jws->getPayload())) {

--- a/php/src/Verifier.php
+++ b/php/src/Verifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TrueLayer\Signing;
 
+use Exception;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\KeyManagement\JWKFactory;
@@ -189,8 +190,11 @@ final class Verifier extends AbstractJws implements IVerifier
      */
     public function verify(string $signature): void
     {
-        $jws = $this->serializerManager
-            ->unserialize($signature);
+        try {
+            $jws = $this->serializerManager->unserialize($signature);
+        } catch (Exception $e) {
+            throw new InvalidSignatureException('Failed to parse JWS: ' . $e->getMessage());
+        }
 
         if (!\is_null($jws->getPayload())) {
             throw new SignatureMustUseDetachedPayloadException();

--- a/php/tests/VerifierTest.php
+++ b/php/tests/VerifierTest.php
@@ -103,6 +103,22 @@ use TrueLayer\Signing\Verifier;
         ->verify($signature);
 })->throws(\TrueLayer\Signing\Exceptions\InvalidSignatureException::class);
 
+// TODO: find a better name
+\it('should throw when the signature is invalid 2', function () {
+    $kid = Uuid::uuid4()->toString();
+    $keys = MockData::generateKeyPair($kid);
+    $verifier = Verifier::verifyWithKey($keys['public']);
+
+    $verifier->method('PUT')
+        ->path('/wrong-path')
+        ->header('X-Idempotency-Key', 'idempotency-test')
+        ->body('{"random-key": "random-value"}')
+        ->requireHeaders([
+            'X-Idempotency-Key',
+        ])
+        ->verify('an-invalid..signature');
+})->throws(\TrueLayer\Signing\Exceptions\InvalidSignatureException::class);
+
 \it('should verify header order/casing flexibility', function () {
     $kid = Uuid::uuid4()->toString();
     $keys = MockData::generateKeyPair($kid);

--- a/php/tests/VerifierTest.php
+++ b/php/tests/VerifierTest.php
@@ -103,8 +103,7 @@ use TrueLayer\Signing\Verifier;
         ->verify($signature);
 })->throws(\TrueLayer\Signing\Exceptions\InvalidSignatureException::class);
 
-// TODO: find a better name
-\it('should throw when the signature is invalid 2', function () {
+\it('should throw when the signature has an invalid format', function () {
     $kid = Uuid::uuid4()->toString();
     $keys = MockData::generateKeyPair($kid);
     $verifier = Verifier::verifyWithKey($keys['public']);
@@ -117,7 +116,7 @@ use TrueLayer\Signing\Verifier;
             'X-Idempotency-Key',
         ])
         ->verify('an-invalid..signature');
-})->throws(\TrueLayer\Signing\Exceptions\InvalidSignatureException::class);
+})->throws(\TrueLayer\Signing\Exceptions\InvalidSignatureException::class, 'Failed to parse JWS: Unsupported input.');
 
 \it('should verify header order/casing flexibility', function () {
     $kid = Uuid::uuid4()->toString();

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.2
+* Improves error handling when parsing and invalid signature.
+
 ## 0.2.1
 * When verifying permit signed/verified path single trailing slash mismatches.
 * Add `path` arg assertions to `TlVerifier.set_path(...)` & `TlSigner.set_path(...)`.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truelayer-signing"
-version = "0.2.1"
+version = "0.2.2"
 description = "Produce & verify TrueLayer API requests signatures"
 authors = ["tl-flavio-barinas <flavio.barinas@truelayer.com>"]
 license = "Apache-2.0 or MIT"

--- a/python/tests/test_tl_sign.py
+++ b/python/tests/test_tl_sign.py
@@ -102,6 +102,24 @@ def test_mismatched_signature_with_attached_valid_body_trailing_dots():
         )
 
 
+def test_verify_with_invalaid_signature_should_raise_exception():
+    body = '{"currency":"GBP","max_amount_in_minor":5000000,"name":"Foo???"}'
+    idempotency_key = "idemp-2076717c-9005-4811-a321-9e0787fa0382"
+    path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping"
+
+    with pytest.raises(TlSigningException) as ex:
+        (
+            verify_with_pem(PUBLIC_KEY)
+            .set_method(HttpMethod.POST)
+            .set_path(path)
+            .add_header("X-Whatever-2", "t2345d")
+            .add_header("Idempotency-Key", idempotency_key)
+            .set_body(body)
+            .verify("an-invalid..signature")
+        )
+    assert ex.value.args[0] == "Failed to parse JWS: 'utf-8' codec can't decode byte 0xa2 in position 2: invalid start byte"
+
+
 def test_signature_no_headers():
     body = '{"currency":"GBP","max_amount_in_minor":5000000}'
     path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping"

--- a/python/truelayer_signing/verify.py
+++ b/python/truelayer_signing/verify.py
@@ -126,7 +126,7 @@ def tl_verify(args: VerifyArguments) -> None:
         missing_headers = " ".join(header_diff)
         raise TlSigningException(f"Missing Required Header(s): {missing_headers}")
 
-    # build the jws paintext
+    # build the jws plaintext
     try:
         _, jws_b64 = build_v2_jws_b64(
             jws_header,
@@ -196,8 +196,8 @@ def extract_jws_header(tl_signature: str) -> JwsHeader:
             decode_url_safe_base64(header_b64).decode()
         )
         return JwsHeader.from_dict(headers)
-    except (UnicodeDecodeError, UnicodeEncodeError, JSONDecodeError):
-        raise TlSigningException("Invalid Signature")
+    except (UnicodeDecodeError, UnicodeEncodeError, JSONDecodeError) as e:
+        raise TlSigningException(f"Failed to parse JWS: {e}", e)
 
 
 def _parse_tl_signature(tl_signature: str) -> Tuple[JwsHeader, bytes]:

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.1.5
+* Improves error handling when parsing and invalid signature.
+
+## 0.1.5
 * When verifying permit signed/verified path single trailing slash mismatches.
 
 ## 0.1.4

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "truelayer-signing"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Alex Butler <alex.butler@truelayer.com>"]
 edition = "2021"
 description = "Produce & verify TrueLayer API requests signatures"

--- a/rust/examples/webhook-server/Cargo.toml
+++ b/rust/examples/webhook-server/Cargo.toml
@@ -12,5 +12,5 @@ truelayer-signing = "0.1.3"
 reqwest = "0.11"
 tracing-subscriber = "0.3.9"
 tracing = "0.1.32"
-reqwest-middleware = "0.1.5"
+reqwest-middleware = "0.2.0"
 http-cache-reqwest = { version = "0.5", default-features = false, features = ["manager-moka"] }

--- a/rust/tests/usage.rs
+++ b/rust/tests/usage.rs
@@ -114,6 +114,24 @@ fn verify_full_request_static_signature() {
         .expect("verify");
 }
 
+#[test]
+fn verify_with_invalid_signature_should_error() {
+    let body = br#"{"currency":"GBP","max_amount_in_minor":5000000,"name":"Foo???"}"#;
+    let idempotency_key = b"idemp-2076717c-9005-4811-a321-9e0787fa0382";
+    let path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping";
+
+    let error = truelayer_signing::verify_with_pem(PUBLIC_KEY)
+        .method("POST")
+        .path(path)
+        .header("X-Whatever-2", b"t2345d")
+        .header("Idempotency-Key", idempotency_key)
+        .body(body)
+        .verify("an-invalid..signature")
+        .expect_err("should error with an invalid signature");
+
+    // TODO: how can I assert on the error's message?
+}
+
 /// Signing a path with a single trailing slash & trying to verify
 /// without that slash should still work. See #80.
 #[test]

--- a/rust/tests/usage.rs
+++ b/rust/tests/usage.rs
@@ -128,10 +128,6 @@ fn verify_with_invalid_signature_should_error() {
         .body(body)
         .verify("an-invalid..signature")
         .expect_err("should error with an invalid signature");
-
-    // TODO: how can I assert on the error's message?
-    // Something like:
-    // assert_eq!(error.message, "jws signing/verification failed: ...");
 }
 
 /// Signing a path with a single trailing slash & trying to verify

--- a/rust/tests/usage.rs
+++ b/rust/tests/usage.rs
@@ -1,3 +1,6 @@
+use anyhow::anyhow;
+use truelayer_signing::Error;
+
 const PUBLIC_KEY: &[u8] = include_bytes!("../../test-resources/ec512-public.pem");
 const PRIVATE_KEY: &[u8] = include_bytes!("../../test-resources/ec512-private.pem");
 const KID: &str = "45fc75cf-5649-4134-84b3-192c2c78e990";
@@ -126,8 +129,9 @@ fn verify_with_invalid_signature_should_error() {
         .header("X-Whatever-2", b"t2345d")
         .header("Idempotency-Key", idempotency_key)
         .body(body)
-        .verify("an-invalid..signature")
-        .expect_err("should error with an invalid signature");
+        .verify("an-invalid..signature");
+
+    assert!(matches!(error, Err(Error::JwsError(_))));
 }
 
 /// Signing a path with a single trailing slash & trying to verify

--- a/rust/tests/usage.rs
+++ b/rust/tests/usage.rs
@@ -130,6 +130,8 @@ fn verify_with_invalid_signature_should_error() {
         .expect_err("should error with an invalid signature");
 
     // TODO: how can I assert on the error's message?
+    // Something like:
+    // assert_eq!(error.message, "jws signing/verification failed: ...");
 }
 
 /// Signing a path with a single trailing slash & trying to verify


### PR DESCRIPTION
Improves error handling and readability of the error when parsing a signature in an invalid format.