### PR TITLE
Potential fix to enum string representation issue in python 3.11.

### DIFF
--- a/python/truelayer_signing/utils.py
+++ b/python/truelayer_signing/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import base64
 import json
 from dataclasses import asdict, dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Dict, Generic, Iterable, Mapping, Optional, Tuple, TypeVar, Union
 
 # local imports
@@ -17,7 +17,7 @@ P = TypeVar("P", str, Union[str, Mapping[str, str]])
 T = TypeVar("T", bound="TlJwsBase")  # type: ignore
 
 
-class HttpMethod(str, Enum):
+class HttpMethod(StrEnum):
     POST = "POST"
     GET = "GET"
     PATCH = "PATCH"


### PR DESCRIPTION
There is an issue with the string representation of HttpMethod(str ,Enum)  in python 3.11.

The function build_v2_signing_payload in utils.py depends on the  string representation of the method being a valid http method, but in python 3.11 the string representation  has 'HttpMethod.' prepended to the string As an example, when making a POST request the signature is being creating with 'HttpMethod.POST' rather than 'POST' as the method and so is invalid.

I'm not sure if changing this to  HttpMethod(str ,Enum) to HttpMethod(StrEnum) is backwards compatible. Someone could come up with another fix for this if not.
