### PR TITLE
[EWT-84] Improve release process - dotnet

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.x'
@@ -31,9 +31,22 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'
     - run: cd csharp/examples/webhook-server && dotnet build
     - run: cd csharp/examples/sign-request && dotnet build
+  
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: |
+        dotnet pack src/truelayer-signing.csproj \
+          --configuration Release \
+          --include-source \
+          -property:SymbolPackageFormat=snupkg
+        dotnet nuget push src/bin/Release/TrueLayer.Signing.*.nupkg \
+          --source https://api.nuget.org/v3/index.json \
+          --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -40,7 +40,7 @@ jobs:
   
   publish:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'  # Runs only on commit on main branch
+    if: github.ref == 'refs/heads/main'  # Runs only on commits on main branch
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -40,8 +40,7 @@ jobs:
   
   publish:
     runs-on: ubuntu-latest
-    # TODO: temporarily commented to test the pipeline without merging into main
-    #if: github.ref == 'refs/heads/main'  # Runs only on commit on main branch
+    if: github.ref == 'refs/heads/main'  # Runs only on commit on main branch
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -40,6 +40,7 @@ jobs:
   
   publish:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'  # Runs only on commit in main
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -42,11 +42,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: |
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Generate NuGet package
+      run: |
+        cd csharp
         dotnet pack src/truelayer-signing.csproj \
           --configuration Release \
           --include-source \
           -property:SymbolPackageFormat=snupkg
+    - name: Push to NuGet
+      run: |
         dotnet nuget push src/bin/Release/TrueLayer.Signing.*.nupkg \
           --source https://api.nuget.org/v3/index.json \
           --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -57,6 +57,7 @@ jobs:
           -property:SymbolPackageFormat=snupkg
     - name: Push to NuGet
       run: |
+        cd csharp
         dotnet nuget push src/bin/Release/TrueLayer.Signing.*.nupkg \
           --source https://api.nuget.org/v3/index.json \
           --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -40,7 +40,8 @@ jobs:
   
   publish:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'  # Runs only on commit in main
+    # TODO: temporarily commented to test the pipeline without merging into main
+    #if: github.ref == 'refs/heads/main'  # Runs only on commit on main branch
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ See [request-signing-v2.md](./request-signing-v2.md) for an explanation of how r
 TrueLayer webhooks include a `Tl-Signature` header similar to request signatures but signed by a TrueLayer private key.
 See per-language examples on how to properly verify webhooks.
 
-#### License
+## Contributing
+
+Contributions are always welcome!
+
+See our [contributing guide](./CONTRIBUTING.md) and our [wiki](https://github.com/TrueLayer/truelayer-signing/wiki).
+
+Please adhere to this project's [code of conduct](CODE_OF_CONDUCT.md).
+
+## License
 
 <sup>
 Licensed under either of <a href="LICENSE-APACHE">Apache License, Version

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -42,5 +42,3 @@ See [webhook server example](./examples/webhook-server/).
 
 ## Compatibility
 .NET Standard 2.0 is supported however .NET Framework 4.6.x **is not** as it's missing required cryptography libraries. For .NET Framework use 4.7.x or higher.
-
-// TODO: delete me, I'm here just to trigger the pipeline

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -42,3 +42,5 @@ See [webhook server example](./examples/webhook-server/).
 
 ## Compatibility
 .NET Standard 2.0 is supported however .NET Framework 4.6.x **is not** as it's missing required cryptography libraries. For .NET Framework use 4.7.x or higher.
+
+// TODO: delete me, I'm here just to trigger the pipeline


### PR DESCRIPTION
Automate the release process by eliminating the needs for a manual release to NuGet.

The changes were tested [running the pipeline without merging the PR](https://github.com/TrueLayer/truelayer-signing/actions/runs/3912895731) in `main`: the result is a [conflicting push to NuGet](https://github.com/TrueLayer/truelayer-signing/actions/runs/3912895731/jobs/6688115243#step:5:12), which is expected since the version is the same as the one in the NuGet repository.
In a real case scenario that operation is expected to succeed.

Also adds guidelines on how to release the library in the [Wiki](https://github.com/TrueLayer/truelayer-signing/wiki/Versioning-and-Publishing#c).