### PR TITLE
Ruby: fix webhook server example

### DIFF
--- a/ruby/examples/webhook-server/Gemfile
+++ b/ruby/examples/webhook-server/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "truelayer-signing"
+gem "webrick"

--- a/ruby/examples/webhook-server/main.rb
+++ b/ruby/examples/webhook-server/main.rb
@@ -1,5 +1,5 @@
-require 'truelayer-signing'
 require 'securerandom'
+require 'truelayer-signing'
 require 'webrick'
 
 class TrueLayerSigningExamples

--- a/ruby/examples/webhook-server/main.rb
+++ b/ruby/examples/webhook-server/main.rb
@@ -1,57 +1,57 @@
-require "socket"
-require "truelayer-signing"
+require 'truelayer-signing'
+require 'securerandom'
+require 'webrick'
 
 class TrueLayerSigningExamples
   # Note: the webhook path can be whatever is configured for your application.
   # Here a unique path is used, matching the example signature in the README.
   WEBHOOK_PATH = "/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b".freeze
-  PUBLIC_KEY_PEM = "-----BEGIN PUBLIC KEY-----\n" +
-    "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBJ6ET9XeVCyMy+yOetZaNNCXPhwr5\n" +
-    "BlyDDg1CLmyNM5SvqOs8RveL6dYl4lpPur4xrPQl04ggYlVd9wnHkZnp3jcBlXw8\n" +
-    "Lc5phyYF1q2/QV/5wp2WHIhKDqUiXC0TvlE8d7MdTAN9yolcwrh6aWZ3kesTMZif\n" +
-    "BgItyT6PXUab8mMdI8k=\n-----END PUBLIC KEY-----"
+  PUBLIC_KEY_PEM = <<~TXT.freeze
+    -----BEGIN PUBLIC KEY-----
+    MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBJ6ET9XeVCyMy+yOetZaNNCXPhwr5
+    BlyDDg1CLmyNM5SvqOs8RveL6dYl4lpPur4xrPQl04ggYlVd9wnHkZnp3jcBlXw8
+    Lc5phyYF1q2/QV/5wp2WHIhKDqUiXC0TvlE8d7MdTAN9yolcwrh6aWZ3kesTMZif
+    BgItyT6PXUab8mMdI8k=
+    -----END PUBLIC KEY-----
+  TXT
 
   class << self
     def run_webhook_server
-      server = TCPServer.new(4567)
+      ensure_certificate_id_present!
+
+      server = WEBrick::HTTPServer.new(Port: 4567)
 
       puts "Server running at http://localhost:4567"
 
-      loop do
-        Thread.start(server.accept) do |client|
-          begin
-            request = parse_request(client)
-            status, body = handle_request.call(request)
-            headers = { "Content-Type" => "text/plain" }
+      server.mount_proc('/') do |req, res|
+        request = parse_request(req)
+        status, body = handle_request.call(request)
+        headers = { "Content-Type" => "text/plain" }
 
-            send_response(client, status, headers, body)
-          rescue => error
-            puts error
-          ensure
-            client.close
-          end
-        end
+        send_response(res, status, headers, body)
+      rescue => error
+        puts error
       end
+
+      server.start
+    ensure
+      server.shutdown
     end
 
-    private def parse_request(client)
-      request = client.gets
-      headers, body = client.readpartial(2048).split("\r\n\r\n", 2)
-      method, remainder = request.split(" ", 2)
-      url = remainder.split(" ").first
-      path, _query_strings = url.split("?", 2)
+    private
 
+    def parse_request(request)
       {
-        method: method,
-        path: path,
-        headers: headers_to_hash(headers),
-        body: body
+        method: request.request_method,
+        path: request.path,
+        headers: headers_to_hash(request.header),
+        body: request.body
       }
     end
 
-    private def handle_request
+    def handle_request
       Proc.new do |request|
-        if request[:method] == "POST" and request[:path] == WEBHOOK_PATH
+        if request[:method] == "POST" && request[:path] == WEBHOOK_PATH
           verify_webhook(request[:path], request[:headers], request[:body])
         else
           ["403", "Forbidden"]
@@ -59,13 +59,14 @@ class TrueLayerSigningExamples
       end
     end
 
-    private def verify_webhook(path, headers, body)
+    def verify_webhook(path, headers, body)
       tl_signature = headers["tl-signature"]
 
       return ["400", "Bad Request – Header `Tl-Signature` missing"] unless tl_signature
 
       begin
-        TrueLayerSigning.verify_with_pem(PUBLIC_KEY_PEM)
+        TrueLayerSigning
+          .verify_with_pem(PUBLIC_KEY_PEM)
           .set_method(:post)
           .set_path(path)
           .set_headers(headers)
@@ -78,19 +79,19 @@ class TrueLayerSigningExamples
       end
     end
 
-    private def send_response(client, status, headers, body)
-      client.print("HTTP/1.1 #{status}\r\n")
-      headers.each { |key, value| client.print("#{key}: #{value}\r\n") }
-      client.print("\r\n#{body}")
+    def headers_to_hash(headers)
+      headers.transform_keys { |key| key.to_s.strip.downcase }.transform_values(&:first)
     end
 
-    private def headers_to_hash(headers_string, hash = Hash.new)
-      headers_string.split("\r\n").each do |line|
-        pair = line.split(":")
-        hash[pair.first.to_s.strip.downcase] = pair.last.to_s.strip
-      end
+    def send_response(response, status, headers, body)
+      response.status = status
+      response.header.merge!(headers)
+      response.body = body
+      response
+    end
 
-      hash
+    def ensure_certificate_id_present!
+      TrueLayerSigning.certificate_id || (TrueLayerSigning.certificate_id = SecureRandom.uuid)
     end
   end
 end


### PR DESCRIPTION
### Issue
The ruby webhook server example introduced in https://github.com/TrueLayer/truelayer-signing/pull/148 does not work correctly. I am getting 401 - "Unauthorized" after doing all the steps from Readme.md

### Implementation details
In the current PR, I've restored the broken ruby webhook server example. Related to https://github.com/TrueLayer/truelayer-signing/issues/177

The reason was incorrect `TrueLayerSigning` settings, and incorrect parsing of request headers.


- Introduced `ensure_certificate_id_present!` method which checks the certificate is present or assigns a random one. This fixed `TRUELAYER_SIGNING_CERTIFICATE_ID is missing` error from [truelayer-signing/ruby/lib/truelayer-signing/utils.rb](https://github.com/TrueLayer/truelayer-signing/blob/b64bb284f58b2d6a86622d18943c585744ff8ef3/ruby/lib/truelayer-signing/utils.rb#L6).
- Server moved to `webrick` to get convinient access to headers, path, and body.
- In the previous implementation, the `x-tl-webhook-timestamp`  header was parsed to incorrect value  `33Z`, leading to the failing signature verification.
