### PR TITLE
Ruby: fix conflict with JWT library

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Build and install gem
-        run: gem build truelayer-signing.gemspec && gem install ./truelayer-signing-0.1.1.gem
+        run: gem build truelayer-signing.gemspec && gem install ./truelayer-signing-0.1.2.gem
       - name: Run tests
         run: rake test

--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ...
 
+## [0.1.2] – 2023-05-19
+
+- Fix conflict with JWT library
+
 ## [0.1.1] – 2023-05-17
 
 - Fix webhook server example

--- a/ruby/lib/truelayer-signing/jwt.rb
+++ b/ruby/lib/truelayer-signing/jwt.rb
@@ -2,19 +2,40 @@
 # It prevents the payload from being systematically converted to and from JSON.
 # To be changed in the 'jwt' gem directly, or hard-coded in this library.
 module JWT
-  class Encode
+  module_function
+
+  class TrueLayerEncode < Encode
     # See https://github.com/jwt/ruby-jwt/blob/main/lib/jwt/encode.rb#L53-L55
     private def encode_payload
       ::JWT::Base64.url_encode(@payload)
     end
   end
 
-  class Decode
+  class TrueLayerDecode < Decode
     # See https://github.com/jwt/ruby-jwt/blob/main/lib/jwt/decode.rb#L154-L156
     private def payload
       @payload ||= ::JWT::Base64.url_decode(@segments[1])
     rescue ::JSON::ParserError
       raise JWT::DecodeError, 'Invalid segment encoding'
     end
+  end
+
+  def truelayer_encode(payload, key, algorithm, headers)
+    TrueLayerEncode.new(
+      payload: payload,
+      key: key,
+      algorithm: algorithm,
+      headers: headers
+    ).segments
+  end
+
+  def truelayer_decode(jwt, key, verify, options, &keyfinder)
+    TrueLayerDecode.new(
+      jwt,
+      key,
+      verify,
+      configuration.decode.to_h.merge(options),
+      &keyfinder
+    ).decode_segments
   end
 end

--- a/ruby/lib/truelayer-signing/signer.rb
+++ b/ruby/lib/truelayer-signing/signer.rb
@@ -9,7 +9,8 @@ module TrueLayerSigning
       jws_header_args = { tl_headers: headers }
       jws_header_args[:jku] = jws_jku if jws_jku
       jws_header = TrueLayerSigning::JwsHeader.new(jws_header_args).to_h
-      jwt = JWT.encode(build_signing_payload, private_key, TrueLayerSigning.algorithm, jws_header)
+      jwt = JWT.truelayer_encode(build_signing_payload, private_key, TrueLayerSigning.algorithm,
+        jws_header)
       header, _, signature = jwt.split(".")
 
       "#{header}..#{signature}"

--- a/ruby/lib/truelayer-signing/verifier.rb
+++ b/ruby/lib/truelayer-signing/verifier.rb
@@ -27,7 +27,7 @@ module TrueLayerSigning
       jwt_options = { algorithm: TrueLayerSigning.algorithm }
 
       begin
-        JWT.decode(full_signature, public_key, true, jwt_options)
+        JWT.truelayer_decode(full_signature, public_key, true, jwt_options)
       rescue JWT::VerificationError
         @path = path.end_with?("/") && path[0...-1] || path + "/"
         payload_b64 = Base64.urlsafe_encode64(build_signing_payload(ordered_headers),
@@ -35,7 +35,7 @@ module TrueLayerSigning
         full_signature = [jws_header_b64, payload_b64, signature_b64].join(".")
 
         begin
-          JWT.decode(full_signature, public_key, true, jwt_options)
+          JWT.truelayer_decode(full_signature, public_key, true, jwt_options)
         rescue
           raise(Error, "Signature verification failed")
         end

--- a/ruby/truelayer-signing.gemspec
+++ b/ruby/truelayer-signing.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.unshift(::File.join(::File.dirname(__FILE__), "lib"))
 
 Gem::Specification.new do |s|
   s.name = "truelayer-signing"
-  s.version = "0.1.1"
+  s.version = "0.1.2"
   s.summary = "Ruby gem to produce and verify TrueLayer API requests signatures"
   s.description = "TrueLayer provides instant access to open banking to " \
     "easily integrate next-generation payments and financial data into any app." \


### PR DESCRIPTION
The custom code patch we have for the `jwt` library, which prevents the payload object to be systematically parsed as JSON, breaks the original `JWT.encode` and `JWT.decode` methods. That's a problem for applications already using `JWT` for other purposes, since adding `truelayer-signing` suddenly causes unexpected errors.

This introduces the `JWT.truelayer_encode` and `JWT.truelayer_decode` methods, which allow us to modify the behaviour without compromising the underlying functionality. At some point we should propose a change to the `JWT` library and remove this custom code patch.