### PR TITLE
Ruby: disable expiration verification

### DIFF
--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Disable expiration verification
 - ...
 
 ## [0.2.0] – 2023-06-13

--- a/ruby/lib/truelayer-signing/jwt.rb
+++ b/ruby/lib/truelayer-signing/jwt.rb
@@ -29,7 +29,7 @@ module JWT
     ).segments
   end
 
-  def truelayer_decode(jwt, key, verify, options, &keyfinder)
+  def truelayer_decode(jwt, key, verify = true, options, &keyfinder)
     TrueLayerDecode.new(
       jwt,
       key,

--- a/ruby/lib/truelayer-signing/signer.rb
+++ b/ruby/lib/truelayer-signing/signer.rb
@@ -7,7 +7,9 @@ module TrueLayerSigning
 
       private_key = OpenSSL::PKey.read(TrueLayerSigning.private_key)
       jws_header_args = { tl_headers: headers }
+
       jws_header_args[:jku] = jws_jku if jws_jku
+
       jws_header = TrueLayerSigning::JwsHeader.new(jws_header_args).to_h
       jwt = JWT.truelayer_encode(build_signing_payload, private_key, TrueLayerSigning.algorithm,
         jws_header)
@@ -18,6 +20,7 @@ module TrueLayerSigning
 
     def set_jku(jku)
       @jws_jku = jku
+
       self
     end
 

--- a/ruby/lib/truelayer-signing/utils.rb
+++ b/ruby/lib/truelayer-signing/utils.rb
@@ -16,12 +16,14 @@ module TrueLayerSigning
 
     def to_h
       hash = instance_variables.map { |var| [var[1..-1].to_sym, instance_variable_get(var)] }.to_h
+
       hash.reject { |key, _value| hash[key].nil? }
     end
 
     def filter_headers(headers)
       required_header_keys = tl_headers.split(",").reject { |key| key.empty? }
       normalised_headers = {}
+
       headers.to_a.each { |header| normalised_headers[header.first.downcase] = header.last }
 
       ordered_headers = required_header_keys.map do |key|
@@ -50,6 +52,7 @@ module TrueLayerSigning
 
     def set_method(method)
       @method = method.to_s.upcase
+
       self
     end
 
@@ -57,21 +60,25 @@ module TrueLayerSigning
       raise(Error, "Path must start with '/'") unless path.start_with?("/")
 
       @path = path
+
       self
     end
 
     def add_header(name, value)
       @headers[name.to_s] = value
+
       self
     end
 
     def set_headers(headers)
       headers.each { |name, value| @headers[name.to_s] = value }
+
       self
     end
 
     def set_body(body)
       @body = body
+
       self
     end
 

--- a/ruby/test/resources/failed-payment-expired-test-payload.json
+++ b/ruby/test/resources/failed-payment-expired-test-payload.json
@@ -1,0 +1,12 @@
+{
+  "type": "payment_failed",
+  "event_version": 1,
+  "event_id": "6f00897f-f8c8-4ffb-93a3-cfbd311396e2",
+  "payment_id": "2c4db314-b509-4d68-b883-a34ca5fa7b72",
+  "payment_method": {
+    "type": "bank_transfer"
+  },
+  "failed_at": "2023-07-11T17:42:24.123Z",
+  "failure_stage": "authorization_required",
+  "failure_reason": "expired"
+}


### PR DESCRIPTION
Verification of expired-payment webhook signatures is failing. This is
because the underlying `jwt` library expects the payload to be a JSON
object, but ours isn't, as per our request signing spec. This breaks
some code paths and the expiration verification was missed by our
manual/automated tests.

This disable expiration verification, as well as any other verification
that expects the payload to be a JSON object.

Jira ticket: https://truelayer.atlassian.net/browse/RSK-647