### PR TITLE
NodeJS: fix failing tests

### DIFF
--- a/nodejs/src/__tests__/usage.test.ts
+++ b/nodejs/src/__tests__/usage.test.ts
@@ -525,7 +525,7 @@ describe('extractKid', () => {
 describe('extractKidInvalidSignature', () => {
   it('should throw using an invalid signature', () => {
     const fn = () => extractKid("an-invalid..signature")
-    expect(fn).toThrow(new SignatureError("Failed to parse JWS: Unexpected token j in JSON at position 0"));
+    expect(fn).toThrow(new SignatureError("Failed to parse JWS: Unexpected token 'j', \"j�����\" is not valid JSON"));
   });
 });
 
@@ -540,6 +540,6 @@ describe('extractJku', () => {
 describe('extractJkuInvalidSignature', () => {
   it('should throw using an invalid signature', () => {
     const fn = () => extractJku("an-invalid..signature")
-    expect(fn).toThrow(new SignatureError("Failed to parse JWS: Unexpected token j in JSON at position 0"));
+    expect(fn).toThrow(new SignatureError("Failed to parse JWS: Unexpected token 'j', \"j�����\" is not valid JSON"));
   });
 });


### PR DESCRIPTION
A couple of error messages have changed in format following some
dependency updates. This updates the affected tests as needed.