### PR TITLE
Ruby: configure gem auto-publishing

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Lint code
         run: rubocop
       - name: Build and install gem
-        run: gem build truelayer-signing.gemspec && gem install ./truelayer-signing-0.2.1.gem
+        run: gem build truelayer-signing.gemspec && gem install "./truelayer-signing-*.*.*.gem"
       - name: Run tests
         run: rake test
   publish:


### PR DESCRIPTION
Adds a `publish` job to the GitHub workflows for Ruby. This will
automatically publish the gem to RubyGems.org if:

- any changes are made to the Ruby files or shared resources;
- the lint and test results are successful;
- there is a new `ruby/v*` tag present;
- the version of the gem is greater than the latest release.