### PR TITLE
Python: publish on version bump only

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -53,6 +53,8 @@ jobs:
 
   check_version:
     runs-on: ubuntu-latest
+    # Runs only on the main branch
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: lint_and_test
     outputs:
       version: ${{ steps.get_version.outputs.VERSION }}
@@ -71,8 +73,8 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    # if: ${{ github.ref == 'refs/heads/main' && needs.check_version.outputs.is_published == false }}
-    if: ${{ needs.check_version.outputs.is_published == false }}
+    # Runs only on the main branch and if the current version isn't already published
+    if: ${{ github.ref == 'refs/heads/main' && needs.check_version.outputs.is_published == false }}
     needs: [lint_and_test, check_version]
     env:
       python-version: "3.10"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,8 +6,6 @@ name: Python package
 on:
   push:
     branches: [ main ]
-    tags:
-      - 'python/v**'
     paths:
       - '.github/workflows/python.yml'
       - 'python/**/*.py'
@@ -53,11 +51,29 @@ jobs:
         run: |
           poetry run pytest --cov=truelayer_signing -v tests/
 
+  check_version:
+    runs-on: ubuntu-latest
+    needs: lint_and_test
+    outputs:
+      version: ${{ steps.get_version.outputs.VERSION }}
+      is_published: ${{ steps.check_published.outputs.IS_PUBLISHED }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get current version
+        id: get_version
+        run: echo VERSION="$(grep -m1 'version = "' pyproject.toml | cut -d '"' -f2)" >> $GITHUB_OUTPUT
+      - name: Check if it's already published
+        id: check_published
+        run: |
+          PACKAGE_URL=https://pypi.org/pypi/truelayer-signing/${{ steps.get_version.outputs.VERSION }}/json
+          STATUS_CODE=$(curl --write-out %{http_code} --silent --output /dev/null $PACKAGE_URL)
+          echo IS_PUBLISHED=$(([ $STATUS_CODE -eq 200 ] && echo true ) || echo false) >> $GITHUB_OUTPUT
+
   publish:
     runs-on: ubuntu-latest
-    # Runs only on tag pushes for Python (combined with line 10) and if lint_and_test succeeded
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    needs: lint_and_test
+    # if: ${{ github.ref == 'refs/heads/main' && needs.check_version.outputs.is_published == false }}
+    if: ${{ needs.check_version.outputs.is_published == false }}
+    needs: [lint_and_test, check_version]
     env:
       python-version: "3.10"
     strategy:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,6 +6,8 @@ name: Python package
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'python/v**'
     paths:
       - '.github/workflows/python.yml'
       - 'python/**/*.py'
@@ -17,12 +19,13 @@ on:
       - 'python/**/*.py'
       - 'python/pyproject.toml'
 
+defaults:
+  run:
+    working-directory: ./python
+
 jobs:
-  build:
+  lint_and_test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./python
     strategy:
       fail-fast: false
       matrix:
@@ -52,10 +55,9 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'  # Runs only on commits on main branch
-    defaults:
-      run:
-        working-directory: ./python
+    # Runs only on tag pushes for Python (combined with line 10) and if lint_and_test succeeded
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    needs: lint_and_test
     env:
       python-version: "3.10"
     strategy:


### PR DESCRIPTION
Since #228, the Python workflow will run for any changes in the Python
code, the shared test resources _and_ the Python workflow itself. This
means that when the library version does not change, the `publish` step
simply fails, which does not look good.

This updates the Python workflow so that it will only attempt to publish
the library automatically when there is a version bump on `main`.