### PR TITLE
C#: publish on new tag only

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -3,6 +3,8 @@ name: C#
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'csharp/v**'
     paths:
       - '.github/workflows/csharp.yml'
       - 'csharp/**'
@@ -42,7 +44,9 @@ jobs:
   
   publish:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'  # Runs only on commits on main branch
+    # Runs only on tag pushes for C# (combined with line 7) and if test job succeeded
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    needs: test
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET


### PR DESCRIPTION
Since #228, the C# workflow will run for any changes in the C# code, the
shared test resources _and_ the C# workflow itself. This means that when
the library version does not change, the `publish` step simply fails,
which does not look good.

This updates the C# workflow so that it will only attempt to publish the
library when there is a `csharp/v**` tag being pushed. It does mean that
it now requires an additional manual step, but it also means that we can
more easily batch changes in each version bump, without the workflow
failing in between.