### PR TITLE
Python: release new patch version

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.2
+* Update dependencies.
+
 ## 0.2.3
 * Improves error handling when parsing and invalid signature.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truelayer-signing"
-version = "0.3.1"
+version = "0.3.2"
 description = "Produce & verify TrueLayer API requests signatures"
 authors = ["tl-flavio-barinas <flavio.barinas@truelayer.com>"]
 license = "Apache-2.0 or MIT"


### PR DESCRIPTION
There have been a couple of dependency updates since the last release,
so this bumps up the patch version. The revised workflow should pick up
the new package version and publish it automatically.