### PR TITLE
[PAYINS-464] [csharp] Add capability to sign with function

### DIFF
--- a/csharp/CHANGELOG.md
+++ b/csharp/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.14
+* Add ability to sign with a function provided by the consumer.
+
 ## 0.1.13
 * Improves error handling when parsing and invalid signature.
 

--- a/csharp/src/Signer.cs
+++ b/csharp/src/Signer.cs
@@ -12,7 +12,7 @@ namespace TrueLayer.Signing
     /// <summary>
     /// Builder to generate a Tl-Signature header value using a private key.
     /// </summary>
-    public sealed class Signer
+    public sealed class Signer : Signer<Signer>
     {
         /// <summary>
         /// Start building a request Tl-Signature header value using private key
@@ -41,114 +41,15 @@ namespace TrueLayer.Signing
         /// Start building a request Tl-Signature header value using the key ID of the signing key (kid)
         /// and a function that accepts the payload and returns the signature. 
         /// </summary>
-        public static Signer SignWithFunction(string kid, Func<string, Task<string>> signAsync) => new(kid, signAsync);
-        
-        private readonly string _kid;
-        private readonly ECDsa? _key;
-        private readonly Func<string, Task<string>>? _signAsync;
-        private string _method = "POST";
-        private string _path = "";
-        private readonly Dictionary<string, byte[]> _headers = new(new HeaderNameComparer());
-        private byte[] _body = Array.Empty<byte>();
+        public static FunctionSigner SignWithFunction(string kid, Func<string, Task<string>> signAsync) => new(kid, signAsync);
 
-        private Signer(string kid, ECDsa privateKey)
+        private readonly ECDsa _key;
+        
+        private Signer(string kid, ECDsa privateKey) : base(kid)
         {
-            _kid = kid;
             _key = privateKey;
         }
         
-        private Signer(string kid, Func<string, Task<string>> signAsync)
-        {
-            _kid = kid;
-            _signAsync = signAsync;
-        }
-
-        /// <summary>Add the request method, defaults to `"POST"` if unspecified.</summary>
-        public Signer Method(string method)
-        {
-            _method = method;
-            return this;
-        }
-
-        /// <summary>
-        /// Add the request absolute path starting with a leading `/` and without any trailing slashes.
-        /// </summary>
-        public Signer Path(string path)
-        {
-            if (!path.StartsWith("/"))
-            {
-                throw new ArgumentException($"Invalid path \"{path}\" must start with '/'");
-            }
-            _path = path;
-            return this;
-        }
-
-        /// <summary>
-        /// Add a header name and value.
-        /// May be called multiple times to add multiple different headers.
-        /// <br/>
-        /// Warning: Only a single value per header name is supported.
-        /// </summary>
-        public Signer Header(string name, byte[] value)
-        {
-            _headers.Add(name.Trim(), value);
-            return this;
-        }
-
-        /// <summary>
-        /// Add a header name and value.
-        /// May be called multiple times to add multiple different headers.
-        /// <br/>
-        /// Warning: Only a single value per header name is supported.
-        /// </summary>
-        public Signer Header(string name, string value) => Header(name, value.ToUtf8());
-
-        /// <summary>
-        /// Appends multiple header names and values.
-        /// <br/>
-        /// Warning: Only a single value per header name is supported.
-        /// </summary>
-        public Signer Headers(IEnumerable<KeyValuePair<string, string>> headers)
-        {
-            foreach (var entry in headers)
-            {
-                Header(entry.Key, entry.Value);
-            }
-            return this;
-        }
-
-        /// <summary>
-        /// Appends multiple header names and values.
-        /// <br/>
-        /// Warning: Only a single value per header name is supported.
-        /// </summary>
-        public Signer Headers(IEnumerable<KeyValuePair<string, byte[]>> headers)
-        {
-            foreach (var entry in headers)
-            {
-                Header(entry.Key, entry.Value);
-            }
-            return this;
-        }
-
-        /// <summary>
-        /// Add the full request body.
-        /// Note: This *must* be identical to what is sent with the request.
-        /// </summary>
-        public Signer Body(byte[] body)
-        {
-            _body = body;
-            return this;
-        }
-
-        /// <summary>
-        /// Add the full request body.
-        /// Note: This *must* be identical to what is sent with the request.
-        /// <br/>
-        /// In this method it is assumed the body will be encoded using UTF-8.
-        /// </summary>
-        public Signer Body(string body) => Body(body.ToUtf8());
-
         /// <summary>Produce a JWS `Tl-Signature` v2 header value.</summary>
         public string Sign()
         {
@@ -156,7 +57,7 @@ namespace TrueLayer.Signing
             {
                 throw new InvalidOperationException("Signing key must be set");
             }
-            
+
             var jwsHeaders = CreateJwsHeaders();
             var headerList = _headers.Select(e => (e.Key, e.Value)).ToList();
             var signingPayload = Util.BuildV2SigningPayload(_method, _path, headerList, _body);
@@ -166,7 +67,131 @@ namespace TrueLayer.Signing
                 _key,
                 JwsAlgorithm.ES512,
                 jwsHeaders,
-                options: new JwtOptions { DetachPayload = true });
+                options: new JwtOptions {DetachPayload = true});
+        }
+    }
+
+    public abstract class Signer<TSigner> where TSigner : Signer<TSigner>
+    {
+        private readonly string _kid;
+        private readonly TSigner _this;
+        protected internal string _method = "POST";
+        protected internal string _path = "";
+        protected internal readonly Dictionary<string, byte[]> _headers = new(new HeaderNameComparer());
+        protected internal byte[] _body = Array.Empty<byte>();
+
+        protected internal Signer(string kid)
+        {
+            _kid = kid;
+            _this = (TSigner) this;
+        }
+
+        /// <summary>Add the request method, defaults to `"POST"` if unspecified.</summary>
+        public TSigner Method(string method)
+        {
+            _method = method;
+            return _this;
+        }
+
+        /// <summary>
+        /// Add the request absolute path starting with a leading `/` and without any trailing slashes.
+        /// </summary>
+        public TSigner Path(string path)
+        {
+            if (!path.StartsWith("/"))
+            {
+                throw new ArgumentException($"Invalid path \"{path}\" must start with '/'");
+            }
+
+            _path = path;
+            return _this;
+        }
+
+        /// <summary>
+        /// Add a header name and value.
+        /// May be called multiple times to add multiple different headers.
+        /// <br/>
+        /// Warning: Only a single value per header name is supported.
+        /// </summary>
+        public TSigner Header(string name, byte[] value)
+        {
+            _headers.Add(name.Trim(), value);
+            return _this;
+        }
+
+        /// <summary>
+        /// Add a header name and value.
+        /// May be called multiple times to add multiple different headers.
+        /// <br/>
+        /// Warning: Only a single value per header name is supported.
+        /// </summary>
+        public TSigner Header(string name, string value) => Header(name, value.ToUtf8());
+
+        /// <summary>
+        /// Appends multiple header names and values.
+        /// <br/>
+        /// Warning: Only a single value per header name is supported.
+        /// </summary>
+        public TSigner Headers(IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            foreach (var entry in headers)
+            {
+                Header(entry.Key, entry.Value);
+            }
+
+            return _this;
+        }
+
+        /// <summary>
+        /// Appends multiple header names and values.
+        /// <br/>
+        /// Warning: Only a single value per header name is supported.
+        /// </summary>
+        public TSigner Headers(IEnumerable<KeyValuePair<string, byte[]>> headers)
+        {
+            foreach (var entry in headers)
+            {
+                Header(entry.Key, entry.Value);
+            }
+
+            return _this;
+        }
+
+        /// <summary>
+        /// Add the full request body.
+        /// Note: This *must* be identical to what is sent with the request.
+        /// </summary>
+        public TSigner Body(byte[] body)
+        {
+            _body = body;
+            return _this;
+        }
+
+        /// <summary>
+        /// Add the full request body.
+        /// Note: This *must* be identical to what is sent with the request.
+        /// <br/>
+        /// In this method it is assumed the body will be encoded using UTF-8.
+        /// </summary>
+        public TSigner Body(string body) => Body(body.ToUtf8());
+        
+        protected internal Dictionary<string, object> CreateJwsHeaders() =>
+            new()
+            {
+                {"alg", "ES512"},
+                {"kid", _kid},
+                {"tl_version", "2"},
+                {"tl_headers", string.Join(",", _headers.Select(h => h.Key))},
+            };
+    }
+    
+    public sealed class FunctionSigner : Signer<FunctionSigner>
+    {
+        private readonly Func<string, Task<string>> _signAsync;
+        
+        internal FunctionSigner(string kid, Func<string, Task<string>> signAsync) : base(kid)
+        {
+            _signAsync = signAsync;
         }
         
         /// <summary>Produce a JWS `Tl-Signature` v2 header value.</summary>
@@ -176,11 +201,11 @@ namespace TrueLayer.Signing
             {
                 throw new InvalidOperationException("Signing function must be set");
             }
-            
+
             var jwsHeaders = CreateJwsHeaders();
             var serializedJwsHeaders = JsonSerializer.SerializeToUtf8Bytes(jwsHeaders);
             var serializedJwsHeadersB64 = Base64Url.Encode(serializedJwsHeaders);
-            
+
             var headerList = _headers.Select(e => (e.Key, e.Value)).ToList();
             var signingPayload = Util.BuildV2SigningPayload(_method, _path, headerList, _body);
             var signingPayloadB64 = Base64Url.Encode(signingPayload);
@@ -188,17 +213,8 @@ namespace TrueLayer.Signing
             var signingMessage = $"{serializedJwsHeadersB64}.{signingPayloadB64}";
 
             var signature = await _signAsync(signingMessage);
-            
+
             return $"{serializedJwsHeadersB64}..{signature}";
         }
-        
-        private Dictionary<string, object> CreateJwsHeaders() =>
-            new()
-            {
-                {"alg", "ES512"},
-                {"kid", _kid},
-                {"tl_version", "2"},
-                {"tl_headers", string.Join(",", _headers.Select(h => h.Key))},
-            };
     }
 }

--- a/csharp/src/truelayer-signing.csproj
+++ b/csharp/src/truelayer-signing.csproj
@@ -33,4 +33,10 @@
     <PackageReference Include="System.Text.Json" Version="5.0.1" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.2" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>TrueLayer.Signing.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/csharp/src/truelayer-signing.csproj
+++ b/csharp/src/truelayer-signing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageVersion>0.1.13</PackageVersion>
+    <PackageVersion>0.1.14</PackageVersion>
     <TargetFrameworks>net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Add `Signer.SignWithFunction(string kid, Func<string, Task<string>> signAsync)`  to allow consumers to pass a function which takes the signing payload and returns the signature. This allows signing to be delegated to an external key management service in the case that the library consumer does not have direct access to the private key.

The changes have been implemented in a non-breaking way for existing consumers.

Related PR for JS implementation: https://github.com/TrueLayer/truelayer-signing/pull/178