### PR TITLE
[PHP-74] New JWT library

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -28,9 +28,9 @@ jobs:
           - "lowest"
           - "highest"
         php-version:
-          - "7.4"
-          - "8.0"
           - "8.1"
+          - "8.2"
+          - "8.3"
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4

--- a/php/composer.json
+++ b/php/composer.json
@@ -29,12 +29,9 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "web-token/jwt-core": "^2.2|^3",
-        "web-token/jwt-signature": "^2.2|^3",
-        "web-token/jwt-signature-algorithm-ecdsa": "^2.2|^3",
-        "web-token/jwt-key-mgmt": "^2.2|^3",
-        "psr/http-message": "^1.0.1"
+        "php": "^8.1",
+        "psr/http-message": "^1.1",
+        "web-token/jwt-library": "^3.3"
     },
     "require-dev": {
         "pestphp/pest": "^1.20",

--- a/php/tests/SignerTest.php
+++ b/php/tests/SignerTest.php
@@ -73,5 +73,11 @@ use TrueLayer\Signing\Tests\MockData;
         )
         ->andReturn($requestMock);
 
-    Signer::signWithKey($kid, $keys['private'])->addSignatureHeader($requestMock);
+    $signer = Signer::signWithKey($kid, $keys['private']);
+
+    $signer->addSignatureHeader($requestMock);
+    $signer->method('POST')
+        ->path('/test');
+
+    \expect($signer->sign())->not->toThrow(Exception::class);
 });

--- a/php/tests/VerifierTest.php
+++ b/php/tests/VerifierTest.php
@@ -232,7 +232,12 @@ use TrueLayer\Signing\Verifier;
 });
 
 \it('should verify a valid signature from decoded json', function () {
-    $signature = \trim(\file_get_contents('../test-resources/tl-signature.txt'));
+    $untrimmedSignature = \file_get_contents('../test-resources/tl-signature.txt');
+    if (!is_string($untrimmedSignature)) {
+       throw new Exception("Could not read the test-resources/tl-signature.txt file");
+    }
+
+    $signature = \trim($untrimmedSignature);
     $jwksJson = \file_get_contents('../test-resources/jwks.json');
 
     /**

--- a/php/tests/VerifierTest.php
+++ b/php/tests/VerifierTest.php
@@ -232,7 +232,7 @@ use TrueLayer\Signing\Verifier;
 });
 
 \it('should verify a valid signature from decoded json', function () {
-    $signature = \file_get_contents('../test-resources/tl-signature.txt');
+    $signature = \trim(\file_get_contents('../test-resources/tl-signature.txt'));
     $jwksJson = \file_get_contents('../test-resources/jwks.json');
 
     /**


### PR DESCRIPTION
- switch from abandoned `web-token/jwt-*` to `web-token/jwt-library`
- remove support for end of life PHP versions