### PR TITLE
[PAYINS-600] [csharp] Allow specifying jku when creating signature

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-* @TrueLayer/rust-oss @TrueLayer/paydirect-api
+* @TrueLayer/rust-oss
+csharp/ @TrueLayer/dotnet-libs
 php/ @TrueLayer/php-oss

--- a/csharp/src/Signer.cs
+++ b/csharp/src/Signer.cs
@@ -59,6 +59,7 @@ namespace TrueLayer.Signing
         protected internal string _path = "";
         protected internal readonly Dictionary<string, byte[]> _headers = new(new HeaderNameComparer());
         protected internal byte[] _body = Array.Empty<byte>();
+        protected internal string? _jku;
 
         protected internal Signer(string kid)
         {
@@ -155,14 +156,32 @@ namespace TrueLayer.Signing
         /// </summary>
         public TSigner Body(string body) => Body(body.ToUtf8());
         
-        protected internal Dictionary<string, object> CreateJwsHeaders() =>
-            new()
+        /// <summary>
+        /// Sets the jku (JSON Web Key Set URL) in the JWS headers of the signature. 
+        /// </summary>
+        public TSigner Jku(string jku)
+        {
+            _jku = jku;
+            return _this;
+        }
+
+        protected internal Dictionary<string, object> CreateJwsHeaders()
+        {
+            var jwsHeaders = new Dictionary<string, object>
             {
                 {"alg", "ES512"},
                 {"kid", _kid},
                 {"tl_version", "2"},
                 {"tl_headers", string.Join(",", _headers.Select(h => h.Key))},
             };
+
+            if (_jku is not null)
+            {
+                jwsHeaders.Add("jku", _jku);
+            }
+
+            return jwsHeaders;
+        }
     }
     
     /// <summary>

--- a/csharp/src/truelayer-signing.csproj
+++ b/csharp/src/truelayer-signing.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageVersion>0.1.14</PackageVersion>
+    <PackageVersion>0.1.15</PackageVersion>
     <TargetFrameworks>net5.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Nullable>enable</Nullable>

--- a/csharp/test/UsageTest.cs
+++ b/csharp/test/UsageTest.cs
@@ -431,6 +431,35 @@ namespace TrueLayer.Signing.Tests
                 .Body(body)
                 .Verify(tlSignature); // should not throw
         }
+
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void SignAndVerify_WithJku(TestCase testCase)
+        {
+            var body = "{\"currency\":\"GBP\",\"max_amount_in_minor\":1}";
+            var idempotency_key = $"idemp-{Guid.NewGuid()}";
+            var path = "/payments";
+            var jku = $"https://{Guid.NewGuid()}.com/.well-known/jwks";
+
+            var tlSignature = Signer.SignWithPem(testCase.Kid, testCase.PrivateKey)
+                .Method("POST")
+                .Path(path)
+                .Header("Idempotency-Key", idempotency_key)
+                .Body(body)
+                .Jku(jku)
+                .Sign();
+
+            Verifier.VerifyWithPem(testCase.PublicKey)
+                .Method("post")
+                .Path(path)
+                .Header("X-Extra-1", "qwerty")
+                .Header("IDEMPOTENCY-KEY", idempotency_key)
+                .Body(body)
+                .Verify(tlSignature); // should not throw
+
+            var signatureJku = Verifier.ExtractJku(tlSignature);
+            signatureJku.Should().Be(jku);
+        }
         
         public sealed class TestCase
         {


### PR DESCRIPTION
Allow specifying a `jku` when creating a signature, which will be included in the JWS headers.
This is intended to be used for response signing and will point consumers to TrueLayer's JWKS for validating these signatures.