### PR TITLE
Ruby: fix linter error

### DIFF
--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ...
 
+## [0.2.3] – 2024-07-29
+
+- Fix `Gemspec/AddRuntimeDependency` linter error
+- Pin minor version for `jwt 2.7.0`
+
 ## [0.2.2] – 2023-12-07
 
 - Add code linter

--- a/ruby/truelayer-signing.gemspec
+++ b/ruby/truelayer-signing.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.required_ruby_version = ">= 2.7"
-  s.add_runtime_dependency("jwt", "~> 2.7")
+  s.add_dependency("jwt", "~> 2.7")
 end

--- a/ruby/truelayer-signing.gemspec
+++ b/ruby/truelayer-signing.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "lib"))
 
 Gem::Specification.new do |s|
   s.name = "truelayer-signing"
-  s.version = "0.2.2"
+  s.version = "0.2.3"
   s.summary = "Ruby gem to produce and verify TrueLayer API requests signatures"
   s.description = "TrueLayer provides instant access to open banking to " \
     "easily integrate next-generation payments and financial data into any app." \
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.required_ruby_version = ">= 2.7"
-  s.add_dependency("jwt", "~> 2.7")
+  s.add_dependency("jwt", "~> 2.7.0")
 end


### PR DESCRIPTION
Updates the gemspec file to comply with `Gemspec/AddRuntimeDependency`
(see https://github.com/rubygems/rubygems/issues/7799).