### PR TITLE
Bump Python library from 0.3.5 to 0.3.6

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.6
+
+- Bump cryptography from 42.0.4 to 43.0.1
+
 ## 0.3.5
 
 - Bump idna from 3.4 to 3.7

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "truelayer-signing"
-version = "0.3.5"
+version = "0.3.6"
 description = "Produce & verify TrueLayer API requests signatures"
 authors = ["tl-flavio-barinas <flavio.barinas@truelayer.com>"]
 license = "Apache-2.0 or MIT"


### PR DESCRIPTION
Fixes https://github.com/TrueLayer/truelayer-signing/issues/331