### PR TITLE
Update Ruby gem dependencies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["4.0", "3.4", "3.3", "3.2", "3.1"]
+        ruby-version: ["4.0", "3.4", "3.3", "3.2"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.4", "3.3", "3.2", "3.1"]
+        ruby-version: ["4.0", "3.4", "3.3", "3.2", "3.1"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -19,6 +19,7 @@
 Gemfile.lock
 .ruby-version
 .ruby-gemset
+.tool-versions
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,7 +1,8 @@
 AllCops:
   NewCops: enable
+  SuggestExtensions: false
   # TODO: bump lowest supported version when dropping support
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
 Gemspec/RequireMFA:
   Enabled: false
 Layout/LineEndStringConcatenationIndentation:

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -2,7 +2,7 @@ AllCops:
   NewCops: enable
   SuggestExtensions: false
   # TODO: bump lowest supported version when dropping support
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 Gemspec/RequireMFA:
   Enabled: false
 Layout/LineEndStringConcatenationIndentation:

--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ...
 
-## [0.3.0] – 2025-11-27
+## [0.3.0] – 2025-11-28
 
 - Require Ruby `>= 3.1`
 - Update pinned version for `jwt` from `~> 2.7.0` to `~> 3.1.2`

--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ...
 
+## [0.3.0] – 2025-11-27
+
+- Require Ruby `>= 3.1`
+- Update pinned version for `jwt` from `~> 2.7.0` to `~> 3.1.2`
+
 ## [0.2.3] – 2024-07-29
 
 - Fix `Gemspec/AddRuntimeDependency` linter error
@@ -26,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0] – 2023-06-13
 
 - Add support for signature verification using a JWKS: `TrueLayerSigning.verify_with_jwks(jwks)`
-    and `TrueLayerSigning.extract_jws_header(signature)`.
+  and `TrueLayerSigning.extract_jws_header(signature)`.
 
 ## [0.1.2] – 2023-05-19
 

--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ...
 
-## [0.3.0] – 2026-06-15
+## [0.3.0] – 2026-06-16
 
 - Require Ruby `>= 3.2`
 - Update pinned version for `jwt` from `~> 2.7.0` to `~> 3.2.0`

--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ...
 
-## [0.3.0] – 2025-11-28
+## [0.3.0] – 2026-06-15
 
-- Require Ruby `>= 3.1`
-- Update pinned version for `jwt` from `~> 2.7.0` to `~> 3.1.2`
+- Require Ruby `>= 3.2`
+- Update pinned version for `jwt` from `~> 2.7.0` to `~> 3.2.0`
 
 ## [0.2.3] – 2024-07-29
 

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -2,4 +2,5 @@
 
 source "https://rubygems.org"
 
-gem "rubocop", "~> 1.57", require: false
+gem "rake", "~> 13.3", require: false
+gem "rubocop", "~> 1.81", require: false

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -2,5 +2,5 @@
 
 source "https://rubygems.org"
 
-gem "rake", "~> 13.3", require: false
-gem "rubocop", "~> 1.81", require: false
+gem "rake", "~> 13.4", require: false
+gem "rubocop", "~> 1.87", require: false

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -3,4 +3,4 @@
 source "https://rubygems.org"
 
 gem "rake", "~> 13.4", require: false
-gem "rubocop", "~> 1.87", require: false
+gem "rubocop", "~> 1.88", require: false

--- a/ruby/lib/truelayer-signing/jwt.rb
+++ b/ruby/lib/truelayer-signing/jwt.rb
@@ -35,7 +35,7 @@ module JWT
     ).segments
   end
 
-  # rubocop:disable Style/OptionalArguments, Style/OptionalBooleanParameter
+  # rubocop:disable Style/OptionalArguments, Style/OptionalBooleanParameter, Naming/BlockForwarding
   def truelayer_decode(jwt, key, verify = true, options, &keyfinder)
     TrueLayerDecode.new(
       jwt,
@@ -45,5 +45,5 @@ module JWT
       &keyfinder
     ).decode_segments
   end
-  # rubocop:enable Style/OptionalArguments, Style/OptionalBooleanParameter
+  # rubocop:enable Style/OptionalArguments, Style/OptionalBooleanParameter, Naming/BlockForwarding
 end

--- a/ruby/lib/truelayer-signing/jwt.rb
+++ b/ruby/lib/truelayer-signing/jwt.rb
@@ -16,6 +16,8 @@ module JWT
   class TrueLayerEncode < Encode
     # See https://github.com/jwt/ruby-jwt/blob/main/lib/jwt/encode.rb#L15-L18
     def initialize(options)
+      super
+
       @token     = TrueLayerToken.new(payload: options[:payload], header: options[:headers])
       @key       = options[:key]
       @algorithm = options[:algorithm]
@@ -27,10 +29,10 @@ module JWT
 
     # See https://github.com/jwt/ruby-jwt/blob/main/lib/jwt/encoded_token.rb#L203-L212
     def decode_payload
-      raise JWT::DecodeError, 'Encoded payload is empty' if encoded_payload == ''
+      raise JWT::DecodeError, "Encoded payload is empty" if encoded_payload == ""
 
       if unencoded_payload?
-        verify_claims!(crit: ['b64'])
+        verify_claims!(crit: ["b64"])
         return parse_unencoded(encoded_payload)
       end
 
@@ -41,7 +43,9 @@ module JWT
   class TrueLayerDecode < Decode
     # See https://github.com/jwt/ruby-jwt/blob/main/lib/jwt/decode.rb#L22-L30
     def initialize(jwt, key, verify, options, &keyfinder)
-      raise JWT::DecodeError, 'Nil JSON web token' unless jwt
+      super
+
+      raise JWT::DecodeError, "Nil JSON web token" unless jwt
 
       @token = TrueLayerEncodedToken.new(jwt)
       @key = key

--- a/ruby/lib/truelayer-signing/jwt.rb
+++ b/ruby/lib/truelayer-signing/jwt.rb
@@ -64,8 +64,16 @@ module JWT
     ).segments
   end
 
-  # rubocop:disable Style/OptionalArguments, Style/OptionalBooleanParameter, Naming/BlockForwarding
-  def truelayer_decode(jwt, key, verify = true, options, &keyfinder)
+  # rubocop:disable Style/OptionalBooleanParameter, Naming/BlockForwarding
+  def truelayer_decode(jwt, key, verify = true, options = {}, &keyfinder)
+    # Support both `truelayer_decode(jwt, key, options)` and
+    # `truelayer_decode(jwt, key, verify, options)` call styles by treating a
+    # Hash in the `verify` position as the `options` argument.
+    if verify.is_a?(Hash)
+      options = verify
+      verify = true
+    end
+
     TrueLayerDecode.new(
       jwt,
       key,
@@ -74,5 +82,5 @@ module JWT
       &keyfinder
     ).decode_segments
   end
-  # rubocop:enable Style/OptionalArguments, Style/OptionalBooleanParameter, Naming/BlockForwarding
+  # rubocop:enable Style/OptionalBooleanParameter, Naming/BlockForwarding
 end

--- a/ruby/lib/truelayer-signing/jwt.rb
+++ b/ruby/lib/truelayer-signing/jwt.rb
@@ -14,7 +14,7 @@ module JWT
   end
 
   class TrueLayerEncode < Encode
-    # See https://github.com/jwt/ruby-jwt/blob/main/lib/jwt/encode.rb#L15-L18
+    # See https://github.com/jwt/ruby-jwt/blob/main/lib/jwt/encode.rb#L15-L19
     def initialize(options)
       super
 
@@ -27,7 +27,7 @@ module JWT
   class TrueLayerEncodedToken < EncodedToken
     private
 
-    # See https://github.com/jwt/ruby-jwt/blob/main/lib/jwt/encoded_token.rb#L203-L212
+    # See https://github.com/jwt/ruby-jwt/blob/main/lib/jwt/encoded_token.rb#L189-L198
     def decode_payload
       raise JWT::DecodeError, "Encoded payload is empty" if encoded_payload == ""
 

--- a/ruby/lib/truelayer-signing/verifier.rb
+++ b/ruby/lib/truelayer-signing/verifier.rb
@@ -109,25 +109,10 @@ module TrueLayerSigning
 
         raise(Error, "JWKS does not include given `kid` value") unless jwk
 
-        valid_jwk = apply_zero_padding_as_needed(jwk)
-
-        JWT::JWK::EC.import(valid_jwk).public_key
+        JWT::JWK::EC.import(jwk).public_key
       else
         raise(Error, "Type of public key not recognised")
       end
-    end
-
-    def apply_zero_padding_as_needed(jwk)
-      valid_jwk = jwk.clone
-
-      %i(x y).each do |elem|
-        coords = Base64.urlsafe_decode64(valid_jwk[elem])
-        diff = EXPECTED_EC_KEY_COORDS_LENGTH - coords.length
-
-        valid_jwk[elem] = Base64.urlsafe_encode64(("\x00" * diff) + coords) if diff.positive?
-      end
-
-      valid_jwk
     end
 
     def validate_required_headers!(headers)

--- a/ruby/lib/truelayer-signing/verifier.rb
+++ b/ruby/lib/truelayer-signing/verifier.rb
@@ -2,8 +2,6 @@
 
 module TrueLayerSigning
   class Verifier < JwsBase
-    EXPECTED_EC_KEY_COORDS_LENGTH = 66
-
     attr_reader :required_headers, :key_type, :key_value
 
     def initialize(args)

--- a/ruby/test/test-truelayer-signing.rb
+++ b/ruby/test/test-truelayer-signing.rb
@@ -123,7 +123,7 @@ class TrueLayerSigningTest < Minitest::Test
     body = { currency: "GBP", max_amount_in_minor: 50_000_00, name: "Foo???" }.to_json
     idempotency_key = "idemp-2076717c-9005-4811-a321-9e0787fa0382"
     path = "/merchant_accounts/a61acaef-ee05-4077-92f3-25543a11bd8d/sweeping"
-    tl_signature = read_file("../../test-resources/tl-signature.txt")
+    tl_signature = read_file("../../test-resources/tl-signature.txt").strip
 
     result = TrueLayerSigning.verify_with_pem(PUBLIC_KEY)
       .set_method(:post)
@@ -403,7 +403,7 @@ class TrueLayerSigningTest < Minitest::Test
   end
 
   def test_verify_with_jwks_should_succeed
-    hook_signature = read_file("../../test-resources/webhook-signature.txt")
+    hook_signature = read_file("../../test-resources/webhook-signature.txt").strip
     jwks = read_file("../../test-resources/jwks.json")
     body = { event_type: "example", event_id: "18b2842b-a57b-4887-a0a6-d3c7c36f1020" }.to_json
 
@@ -418,18 +418,6 @@ class TrueLayerSigningTest < Minitest::Test
 
   def test_verify_with_jwks_with_zero_padding_missing_should_succeed
     jwks = read_file("resources/missing-zero-padding-test-jwks.json")
-
-    # JWKS with EC key missing zero padded coords is not supported by `jwt` gem
-
-    jwks_as_json = JSON.parse(jwks, symbolize_names: true)
-    jwk_missing_padding = jwks_as_json[:keys].find { |e| e[:kty] == "EC" }
-    imported_jwk = JWT::JWK::EC.import(jwk_missing_padding)
-
-    error = assert_raises(OpenSSL::PKey::EC::Point::Error) { imported_jwk.public_key.check_key }
-    assert_equal("EC_POINT_bn2point: invalid encoding", error.message)
-
-    # But supported by `truelayer-signing` using zero padding (prepend)
-
     payload = read_file("resources/missing-zero-padding-test-payload.json")
     body = JSON.parse(payload).to_json
 
@@ -438,11 +426,11 @@ class TrueLayerSigningTest < Minitest::Test
       .set_path("/a147f26a-f07e-47e3-9526-d52f1f1fdd55")
       .add_header("x-tl-webhook-timestamp", "2023-06-09T15:40:30Z")
       .set_body(body)
-      .verify(read_file("resources/missing-zero-padding-test-signature.txt"))
+      .verify(read_file("resources/missing-zero-padding-test-signature.txt").strip)
   end
 
   def test_verify_with_jwks_with_wrong_timestamp_should_fail
-    hook_signature = read_file("../../test-resources/webhook-signature.txt")
+    hook_signature = read_file("../../test-resources/webhook-signature.txt").strip
     jwks = read_file("../../test-resources/jwks.json")
     body = { event_type: "example", event_id: "18b2842b-a57b-4887-a0a6-d3c7c36f1020" }.to_json
 

--- a/ruby/truelayer-signing.gemspec
+++ b/ruby/truelayer-signing.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "lib"))
 
 Gem::Specification.new do |s|
   s.name = "truelayer-signing"
-  s.version = "0.2.3"
+  s.version = "0.3.0"
   s.summary = "Ruby gem to produce and verify TrueLayer API requests signatures"
   s.description = "TrueLayer provides instant access to open banking to " \
     "easily integrate next-generation payments and financial data into any app." \

--- a/ruby/truelayer-signing.gemspec
+++ b/ruby/truelayer-signing.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   ]
   s.require_path = "lib"
 
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.1"
   s.add_dependency("jwt", "~> 2.7.0")
 end

--- a/ruby/truelayer-signing.gemspec
+++ b/ruby/truelayer-signing.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.required_ruby_version = ">= 3.1"
-  s.add_dependency("jwt", "~> 2.7.0")
+  s.add_dependency("jwt", "~> 3.1.2")
 end

--- a/ruby/truelayer-signing.gemspec
+++ b/ruby/truelayer-signing.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   ]
   s.require_path = "lib"
 
-  s.required_ruby_version = ">= 3.1"
-  s.add_dependency("jwt", "~> 3.1.2")
+  s.required_ruby_version = ">= 3.2"
+  s.add_dependency("jwt", "~> 3.2.0")
 end


### PR DESCRIPTION
Updates required Ruby version from `>= 2.7` to `>= 3.2`.

Updates pinned version for `jwt` from `~> 2.7.0` to `~> 3.2.0`.

The current version of the `jwt` is structured differently, but non-JSON
payload still isn't supported, so this adapts the logic to match the new
modules and methods of that depencency.

It also removes some custom logic that handled JWKS with missing
zero-padding, which the old version didn't support.

Update gem version from `0.2.3` to `0.3.0`.

Fixes https://github.com/TrueLayer/truelayer-signing/issues/400