### PR TITLE
Fix invalid CodeQL workflow: build language matrix dynamically

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,22 +7,14 @@ on:
     branches: [ main ]
 
 jobs:
-  # Detect which language directories have changed
-  # PHP isn't included here as it's not supported by CodeQL
+  # Detect which language directories changed and build the CodeQL matrix.
+  # PHP isn't included as it's not supported by CodeQL.
   changes:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      actions: ${{ steps.filter.outputs.actions }}
-      csharp: ${{ steps.filter.outputs.csharp }}
-      go: ${{ steps.filter.outputs.go }}
-      java: ${{ steps.filter.outputs.java }}
-      java7: ${{ steps.filter.outputs.java7 }}
-      javascript: ${{ steps.filter.outputs.javascript }}
-      python: ${{ steps.filter.outputs.python }}
-      ruby: ${{ steps.filter.outputs.ruby }}
-      rust: ${{ steps.filter.outputs.rust }}
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -50,9 +42,56 @@ jobs:
             rust:
               - 'rust/**'
 
+      # Build the matrix: all languages on push to main, only the languages
+      # whose directory changed on a pull request (the matrix context isn't
+      # available in a job-level `if`, so the selection has to happen here).
+      # build-mode 'none' matches GitHub's default setup, where CodeQL creates
+      # the database without compiling. Go has no 'none' mode, so it uses
+      # 'autobuild'.
+      - name: Build language matrix
+        id: set-matrix
+        env:
+          ON_MAIN: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          actions: ${{ steps.filter.outputs.actions }}
+          csharp: ${{ steps.filter.outputs.csharp }}
+          go: ${{ steps.filter.outputs.go }}
+          java: ${{ steps.filter.outputs.java }}
+          java7: ${{ steps.filter.outputs.java7 }}
+          javascript: ${{ steps.filter.outputs.javascript }}
+          python: ${{ steps.filter.outputs.python }}
+          ruby: ${{ steps.filter.outputs.ruby }}
+          rust: ${{ steps.filter.outputs.rust }}
+        run: |
+          set -euo pipefail
+
+          declare -A build_mode=(
+            [actions]=none [csharp]=none [go]=autobuild [java]=none
+            [javascript]=none [python]=none [ruby]=none [rust]=none
+          )
+
+          # Whether each CodeQL language changed. Java covers both java/ and java7/.
+          declare -A changed=(
+            [actions]="$actions" [csharp]="$csharp" [go]="$go" [java]="$java"
+            [javascript]="$javascript" [python]="$python" [ruby]="$ruby" [rust]="$rust"
+          )
+          if [ "$java7" = "true" ]; then changed[java]=true; fi
+
+          include=()
+          for lang in actions csharp go java javascript python ruby rust; do
+            if [ "$ON_MAIN" = "true" ] || [ "${changed[$lang]}" = "true" ]; then
+              include+=("{\"language\":\"$lang\",\"build-mode\":\"${build_mode[$lang]}\"}")
+            fi
+          done
+
+          matrix="[$(IFS=,; echo "${include[*]}")]"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Selected matrix: $matrix"
+
   analyze:
     name: Analyze (${{ matrix.language }})
     needs: changes
+    # Skip entirely when no relevant language changed (empty matrix).
+    if: needs.changes.outputs.matrix != '[]'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -62,41 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # build-mode 'none' matches GitHub's default setup: CodeQL creates the
-        # database without compiling the project. Go has no 'none' mode, so it
-        # uses 'autobuild'.
-        include:
-          - language: actions
-            build-mode: none
-          - language: csharp
-            build-mode: none
-          - language: go
-            build-mode: autobuild
-          - language: java
-            build-mode: none
-          - language: javascript
-            build-mode: none
-          - language: python
-            build-mode: none
-          - language: ruby
-            build-mode: none
-          - language: rust
-            build-mode: none
-
-    # On main branch: run for all languages
-    # On PR: only run if the language directory has changed
-    if: |
-      github.event_name == 'push' && github.ref == 'refs/heads/main' ||
-      (github.event_name == 'pull_request' && (
-        (matrix.language == 'actions' && needs.changes.outputs.actions == 'true') ||
-        (matrix.language == 'csharp' && needs.changes.outputs.csharp == 'true') ||
-        (matrix.language == 'go' && needs.changes.outputs.go == 'true') ||
-        (matrix.language == 'java' && (needs.changes.outputs.java == 'true' || needs.changes.outputs.java7 == 'true')) ||
-        (matrix.language == 'javascript' && needs.changes.outputs.javascript == 'true') ||
-        (matrix.language == 'python' && needs.changes.outputs.python == 'true') ||
-        (matrix.language == 'ruby' && needs.changes.outputs.ruby == 'true') ||
-        (matrix.language == 'rust' && needs.changes.outputs.rust == 'true')
-      ))
+        include: ${{ fromJSON(needs.changes.outputs.matrix) }}
 
     steps:
     - name: Checkout repository
@@ -116,4 +121,3 @@ jobs:
       uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{ matrix.language }}"
-


### PR DESCRIPTION
## Summary

Follow-up fix to #409. That workflow was **invalid and never ran** — it failed with:

> `Unrecognized named-value: 'matrix'` (codeql.yml, the job-level `if:`)

The `matrix` context isn't available in a job-level `if:` (only `github`, `needs`, `vars`, `inputs` are), so gating each matrix leg with `matrix.language == '...'` is not allowed.

## Fix

Select languages **before** the matrix exists instead of inside it:

- The `changes` job now builds the analyze matrix as JSON in a `set-matrix` step and exposes it via a single `matrix` output.
  - **Push to `main`:** all languages.
  - **Pull request:** only the languages whose directory changed (Java covers both `java/` and `java7/`).
- The `analyze` job consumes it with `matrix: { include: ${{ fromJSON(needs.changes.outputs.matrix) }} }` and is skipped entirely when the matrix is empty (`if: needs.changes.outputs.matrix != '[]'`).

Behaviour is otherwise unchanged from the intended design: per-language `category`, `build-mode: none` (Go uses `autobuild`), PHP excluded (unsupported by CodeQL), no path filtering.

## Action items

- [x] **Disable default setup** in repo Settings → Code security, or default + advanced setups will produce duplicate/conflicting analyses.
- [ ] **Update branch-protection required checks**: with a dynamic matrix, when a PR changes no language directory the `analyze` job is skipped and **no `Analyze (...)` check is posted at all**. If a CodeQL check is required, such PRs would block — add an always-running aggregator check or adjust the rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
