### PR TITLE
Use npm trusted publishing (OIDC) for nodejs publish

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -34,11 +34,20 @@ jobs:
     # Runs only on tags push
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     needs: test
+    permissions:
+      contents: read
+      # Required for npm trusted publishing via OIDC
+      id-token: write
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
         node-version: 'lts/*'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Upgrade npm
+      # Trusted publishing (OIDC) requires npm >= 11.5.1, newer than the version
+      # bundled with the Node LTS release
+      run: npm install -g npm@latest
     - name: Get version from tag
       uses: actions-ecosystem/action-regex-match@v2
       id: regex-match
@@ -50,7 +59,6 @@ jobs:
       run: |
         cd nodejs
         yarn --frozen-lockfile
-        npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
         VERSION=${{ steps.regex-match.outputs.group1 }}
-        npm version $VERSION
+        npm version $VERSION --no-git-tag-version --allow-same-version
         npm publish

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Upgrade npm
       # Trusted publishing (OIDC) requires npm >= 11.5.1, newer than the version
       # bundled with the Node LTS release
-      run: npm install -g npm@latest
+      run: npm install -g "npm@^11.5.1"
     - name: Get version from tag
       uses: actions-ecosystem/action-regex-match@v2
       id: regex-match
@@ -59,6 +59,10 @@ jobs:
       run: |
         cd nodejs
         yarn --frozen-lockfile
-        VERSION=${{ steps.regex-match.outputs.group1 }}
-        npm version $VERSION --no-git-tag-version --allow-same-version
+        VERSION="${{ steps.regex-match.outputs.group1 }}"
+        if [ -z "$VERSION" ]; then
+          echo "::error::Could not extract a version from tag '${{ github.ref_name }}'"
+          exit 1
+        fi
+        npm version "$VERSION" --no-git-tag-version --allow-same-version
         npm publish

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Upgrade npm
       # Trusted publishing (OIDC) requires npm >= 11.5.1, newer than the version
       # bundled with the Node LTS release
-      run: npm install -g "npm@^11.5.1"
+      run: npm install -g npm@latest
     - name: Get version from tag
       uses: actions-ecosystem/action-regex-match@v2
       id: regex-match


### PR DESCRIPTION
## What

Switch the nodejs `publish` job to npm **trusted publishing (OIDC)**, removing the long-lived `NPM_TOKEN`.

## Why

The publish step failed with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/truelayer-signing
npm error 404  ... could not be found or you do not have permission to access it.
```

A 404 on `PUT` during `npm publish` is npm's **masked auth-failure** response (it returns 404 instead of 403 to avoid leaking package existence). The package exists and is healthy — last successful publish was v0.2.1 on 2025-11-25 — so the cause is the stored `NPM_TOKEN` being expired/revoked, consistent with npm's 2025 deprecation of long-lived classic tokens.

## Changes

- Grant `id-token: write` (and explicit `contents: read`, since a job-level `permissions` block fully overrides the repo top-level one) on the `publish` job.
- Set `registry-url` on `setup-node` so npm knows where to request the OIDC token.
- Upgrade npm to `>= 11.5.1` — required by trusted publishing, newer than the npm bundled with Node LTS.
- Remove the `NPM_TOKEN` auth line entirely.
- Harden the version bump: `npm version $VERSION --no-git-tag-version --allow-same-version`.

## Follow-up

- The `NPM_TOKEN` repo secret is now unused and can be deleted once this is confirmed working.
- This job only runs on `nodejs/v**` tag pushes, so verification requires cutting a tag (e.g. re-push `nodejs/v0.2.3`, which 404'd and was never actually published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)