### PR TITLE
Pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -39,7 +39,7 @@ jobs:
           distribution: ${{ matrix.java-distribution }}
           cache: 'gradle'
       - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v3.5.0
+        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
       - name: Test
         run: cd java && ./gradlew test
 
@@ -82,7 +82,7 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
       - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v3.5.0
+        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
       - name: Publish to Sonatype and Maven Central
         run: cd java && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:
@@ -102,13 +102,13 @@ jobs:
     steps:
       - name: Create tag
         id: create_tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ needs.set-release-version.outputs.project_version }}
           tag_prefix: 'java-v'
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ steps.create_tag.outputs.new_tag }}
           generate_release_notes: false

--- a/.github/workflows/java7.yml
+++ b/.github/workflows/java7.yml
@@ -38,7 +38,7 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v3.5.0
+        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
       - name: Test
         run: cd java7 && ./gradlew test
 
@@ -81,7 +81,7 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v3.5.0
+        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
       - name: Publish to Sonatype and Maven Central
         run: cd java7 && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:
@@ -101,13 +101,13 @@ jobs:
     steps:
       - name: Create tag
         id: create_tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ needs.set-release-version.outputs.project_version }}
           tag_prefix: 'java7-v'
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ steps.create_tag.outputs.new_tag }}
           generate_release_notes: false

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -49,7 +49,7 @@ jobs:
       # bundled with the Node LTS release
       run: npm install -g npm@latest
     - name: Get version from tag
-      uses: actions-ecosystem/action-regex-match@v2
+      uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2
       id: regex-match
       with:
         text: ${{ github.ref_name }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -38,7 +38,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v6
       - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # v2
         with:
           coverage: "pcov"
           php-version: "${{ matrix.php-version }}"
@@ -77,7 +77,7 @@ jobs:
         run: |
           TAG=${GITHUB_REF//tags\/php\//tags\/}
           echo "::set-output name=NEW_TAG::$TAG"
-      - uses: stefandanaita/git-subtree-action@1.2.0
+      - uses: stefandanaita/git-subtree-action@17ca5908d7bc20b9c1f98509be1a541362f965f0 # 1.2.0
         with:
           repo: "truelayer/truelayer-signing-php"
           path: "php"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies
@@ -49,13 +49,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby 3.4
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1
         with:
           ruby-version: 3.4
       - name: Build gem
         run: gem build truelayer-signing.gemspec
       - name: Get gem version
-        uses: actions-ecosystem/action-regex-match@v2
+        uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2
         id: regex-match
         with:
           text: ${{ github.ref_name }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,9 +55,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: MarcoIeni/release-plz-action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5
         with:
           project_manifest: rust/Cargo.toml
         env:


### PR DESCRIPTION
## Summary

Pins all **third-party** GitHub Actions to full-length commit SHAs, following [GitHub's secure-use guidance](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions). A version tag (e.g. `@v3`) is mutable — whoever controls the action can move it to point at new code. Pinning to an immutable commit SHA prevents a compromised or repointed tag from silently running in our workflows.

The human-readable version is preserved as a trailing comment (`# v3`), and Dependabot continues to bump both the SHA and the comment.

## Actions pinned

| Action | Version | Workflow(s) |
|---|---|---|
| `dorny/paths-filter` | v4 | codeql |
| `shivammathur/setup-php` | v2 | php |
| `stefandanaita/git-subtree-action` | 1.2.0 | php |
| `actions-ecosystem/action-regex-match` | v2 | node, ruby |
| `ruby/setup-ruby` | v1 | ruby |
| `dtolnay/rust-toolchain` | stable | rust |
| `MarcoIeni/release-plz-action` | v0.5 | rust |
| `gradle/wrapper-validation-action` | v3.5.0 | java, java7 |
| `mathieudutour/github-tag-action` | v6.2 | java, java7 |
| `softprops/action-gh-release` | v3 | java, java7 |

## Notes

- **GitHub-owned actions left on tags** — `actions/*` (checkout, cache, setup-*) and `github/codeql-action/*` are first-party and out of scope for the third-party guidance.
- **`dtolnay/rust-toolchain@stable`** pins the action *code* only; it still installs the latest stable Rust toolchain at runtime, so build behavior is unchanged.
- Only `uses:` lines changed — no logic or permissions changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
