### PR TITLE
Replace deprecated set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -56,12 +56,12 @@ jobs:
         id: get_project_version
         run: |
           cd java && PROJECT_VERSION=$(./gradlew properties | grep "version:" | awk '{print $2}')
-          echo "::set-output name=project_version::$PROJECT_VERSION"
+          echo "project_version=$PROJECT_VERSION" >> "$GITHUB_OUTPUT"
       - name: Get changed version from last two commits
         id: get_changed_version
         run: |
           CHANGED_VERSION=$(git diff HEAD^ -- ./java/gradle.properties | grep +version= | awk -F "=" '{print $2}')
-          echo "::set-output name=changed_version::$CHANGED_VERSION"
+          echo "changed_version=$CHANGED_VERSION" >> "$GITHUB_OUTPUT"
       - name: Print changed version from last two commits
         run: echo ${{ steps.get_changed_version.outputs.changed_version }}
     outputs:

--- a/.github/workflows/java7.yml
+++ b/.github/workflows/java7.yml
@@ -55,12 +55,12 @@ jobs:
         id: get_project_version
         run: |
           cd java7 && PROJECT_VERSION=$(./gradlew properties | grep "version:" | awk '{print $2}')
-          echo "::set-output name=project_version::$PROJECT_VERSION"
+          echo "project_version=$PROJECT_VERSION" >> "$GITHUB_OUTPUT"
       - name: Get changed version from last two commits
         id: get_changed_version
         run: |
           CHANGED_VERSION=$(git diff HEAD^ -- ./java7/gradle.properties | grep +version= | awk -F "=" '{print $2}')
-          echo "::set-output name=changed_version::$CHANGED_VERSION"
+          echo "changed_version=$CHANGED_VERSION" >> "$GITHUB_OUTPUT"
       - name: Print changed version from last two commits
         run: echo ${{ steps.get_changed_version.outputs.changed_version }}
     outputs:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -76,7 +76,7 @@ jobs:
         id: tag-replacer
         run: |
           TAG=${GITHUB_REF//tags\/php\//tags\/}
-          echo "::set-output name=NEW_TAG::$TAG"
+          echo "NEW_TAG=$TAG" >> "$GITHUB_OUTPUT"
       - uses: stefandanaita/git-subtree-action@17ca5908d7bc20b9c1f98509be1a541362f965f0 # 1.2.0
         with:
           repo: "truelayer/truelayer-signing-php"


### PR DESCRIPTION
## What

The `::set-output::` workflow command is [deprecated](https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/) and produces warnings in Actions runs. This migrates all remaining usages to write to the `$GITHUB_OUTPUT` environment file instead.

## Changes

| Workflow | Outputs migrated |
|----------|------------------|
| `php.yml` | `NEW_TAG` |
| `java.yml` | `project_version`, `changed_version` |
| `java7.yml` | `project_version`, `changed_version` |

Each `echo "::set-output name=KEY::value"` becomes `echo "KEY=value" >> "$GITHUB_OUTPUT"`. Consuming steps reference `steps.<id>.outputs.<key>` and are unchanged. This matches the pattern already used in `codeql.yml` and `python.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)