### PR TITLE
java: update deps, test on each LTS runtime, and release 0.3.0

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -26,22 +26,28 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        java-version: [ 8, 11, 17, 20, 21 ]
+        java-version: [ 8, 11, 17, 21, 25 ]
         java-distribution: [ temurin ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v7
-      - name: Setup JDK
+      # Install three JDKs: 8 for the compile toolchain (the library is always built
+      # to Java 8 bytecode), the matrix version as the test runtime, and 21 last so it
+      # becomes JAVA_HOME and runs Gradle (Gradle 8.x cannot run on Java 25+).
+      - name: Setup JDKs
         uses: actions/setup-java@v5
         with:
-          java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.java-distribution }}
+          java-version: |
+            8
+            ${{ matrix.java-version }}
+            21
           cache: 'gradle'
       - name: Validate gradle wrapper
         uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
-      - name: Test
-        run: cd java && ./gradlew test
+      - name: Test on Java ${{ matrix.java-version }}
+        run: cd java && ./gradlew test -PtestJavaVersion=${{ matrix.java-version }}
 
   set-release-version:
     name: Prepare version to tag and release
@@ -75,11 +81,14 @@ jobs:
     needs: [build-and-test, set-release-version]
     steps:
       - uses: actions/checkout@v7
-      - name: Setup JDK
+      # Java 8 for the compile toolchain; 21 last so it runs Gradle.
+      - name: Setup JDKs
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
           distribution: 'temurin'
+          java-version: |
+            8
+            21
           cache: 'gradle'
       - name: Validate gradle wrapper
         uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -45,7 +45,7 @@ jobs:
             21
           cache: 'gradle'
       - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
+        uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Test on Java ${{ matrix.java-version }}
         run: cd java && ./gradlew test -PtestJavaVersion=${{ matrix.java-version }}
 
@@ -91,7 +91,7 @@ jobs:
             21
           cache: 'gradle'
       - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
+        uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Publish to Sonatype and Maven Central
         run: cd java && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:

--- a/java/CHANGELOG.md
+++ b/java/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0
+* Updated `com.nimbusds:nimbus-jose-jwt` to 10.9.1.
+* Migrated from the end-of-life `org.bouncycastle:bcpkix-jdk15on` to `org.bouncycastle:bcpkix-jdk18on` 1.84.
+* Updated `com.squareup.okhttp3:okhttp` to 5.4.0 and `org.slf4j:slf4j-simple` to 2.0.18 in the examples.
+* Updated the webhook-server example to `io.javalin:javalin` 7.2.2, running on Java 21.
+* Updated Gradle to 8.14.5.
+* The published library remains Java 8 compatible; CI now runs the test suite on Java 8, 11, 17, 21 and 25.
+
+## 0.2.6
+* Force UTF-8 charset when building the payload string.
+
 ## 0.2.5
 * Improves error handling when parsing and invalid signature.
 

--- a/java/examples/webhook-server/build.gradle
+++ b/java/examples/webhook-server/build.gradle
@@ -13,7 +13,7 @@ java {
 }
 
 dependencies {
-    implementation("io.javalin:javalin:4.4.0")
+    implementation("io.javalin:javalin:4.6.8")
     implementation project(':lib')
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '5.4.0'
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.18'

--- a/java/examples/webhook-server/build.gradle
+++ b/java/examples/webhook-server/build.gradle
@@ -8,12 +8,12 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
 dependencies {
-    implementation("io.javalin:javalin:4.6.8")
+    implementation("io.javalin:javalin:7.2.2")
     implementation project(':lib')
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '5.4.0'
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.18'

--- a/java/examples/webhook-server/src/main/java/com/truelayer/signing/examples/webhook_server/WebhookServer.java
+++ b/java/examples/webhook-server/src/main/java/com/truelayer/signing/examples/webhook_server/WebhookServer.java
@@ -15,11 +15,12 @@ public class WebhookServer {
 
         OkHttpClient httpClient = new OkHttpClient.Builder().cache(cache).build();
 
-        Javalin app = Javalin.create().exception(SignatureException.class, (exception, ctx) -> {
-            System.out.println("WARNING: Verification failed " + exception.getMessage());
-            ctx.status(401);
-        }).start(7000);
-
-        app.post("/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b", new WebhookVerificationHandler(httpClient));
+        Javalin.create(config -> config.routes
+                .exception(SignatureException.class, (exception, ctx) -> {
+                    System.out.println("WARNING: Verification failed " + exception.getMessage());
+                    ctx.status(401);
+                })
+                .post("/hook/d7a2c49d-110a-4ed2-a07d-8fdb3ea6424b", new WebhookVerificationHandler(httpClient))
+        ).start(7000);
     }
 }

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -1,6 +1,6 @@
 # Main properties
 group=com.truelayer
-version=0.2.6
+version=0.3.0
 
 # Let Gradle discover the JDKs that actions/setup-java installs in CI, so the Java 8
 # compile toolchain and the per-matrix test toolchain resolve. Unset env vars (e.g.

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -2,6 +2,11 @@
 group=com.truelayer
 version=0.2.6
 
+# Let Gradle discover the JDKs that actions/setup-java installs in CI, so the Java 8
+# compile toolchain and the per-matrix test toolchain resolve. Unset env vars (e.g.
+# locally) are ignored; auto-detection of locally installed JDKs still applies.
+org.gradle.java.installations.fromEnv=JAVA_HOME_8_X64,JAVA_HOME_11_X64,JAVA_HOME_17_X64,JAVA_HOME_21_X64,JAVA_HOME_25_X64
+
 sonatype_repository_url=https://s01.oss.sonatype.org/service/local/
 sonatype_snapshot_repository_url=https://s01.oss.sonatype.org/content/repositories/snapshots/
 

--- a/java/gradle/wrapper/gradle-wrapper.properties
+++ b/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionSha256Sum=6f74b601422d6d6fc4e1f9a1ab6522f642c2fdcbc15ae33ebd30ba3d7198e854
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/java/lib/build.gradle
+++ b/java/lib/build.gradle
@@ -18,6 +18,6 @@ apply from: project.file('test.gradle')
 apply from: project.file('publish.gradle')
 
 dependencies {
-    implementation("org.bouncycastle:bcpkix-jdk15on:1.70")
-    implementation("com.nimbusds:nimbus-jose-jwt:9.37.3")
+    implementation("org.bouncycastle:bcpkix-jdk18on:1.84")
+    implementation("com.nimbusds:nimbus-jose-jwt:10.9.1")
 }

--- a/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
+++ b/java/lib/src/test/java/com/truelayer/signing/UsageTest.java
@@ -376,7 +376,7 @@ public class UsageTest {
                 SignatureException.class,
                 () -> Verifier.extractJku("an-invalid..signature")
         );
-        assertEquals("Failed to parse JWS: Invalid JWS header: Invalid JSON: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $", e.getMessage());
+        assertEquals("Failed to parse JWS: Invalid JWS header: Invalid JSON object", e.getMessage());
     }
 
     @Test
@@ -415,7 +415,7 @@ public class UsageTest {
                         .body("{}")
                         .verify("an-invalid..signature")
         );
-        assertEquals("Failed to parse JWS: Invalid JSON: java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $", e.getMessage());
+        assertEquals("Failed to parse JWS: Invalid JSON object", e.getMessage());
     }
 
     @Test

--- a/java/lib/test.gradle
+++ b/java/lib/test.gradle
@@ -8,6 +8,15 @@ tasks.named('test') {
         languageVersion = JavaLanguageVersion.of(testJavaVersion)
     }
 
+    doFirst {
+        // Surface the three distinct JVMs this build uses so each CI matrix job
+        // (and local runs) can confirm them at a glance.
+        def compileJvm = tasks.named('compileJava').get().javaCompiler.get().metadata.javaRuntimeVersion
+        logger.lifecycle("Compile JVM (toolchain): ${compileJvm}")
+        logger.lifecycle("Gradle daemon JVM: ${System.getProperty('java.version')} (JAVA_HOME=${System.getenv('JAVA_HOME')})")
+        logger.lifecycle("Test runtime JVM: ${javaLauncher.get().metadata.javaRuntimeVersion}")
+    }
+
     testLogging {
         events "passed", "skipped", "failed" //, "standardOut", "standardError"
         showExceptions true

--- a/java/lib/test.gradle
+++ b/java/lib/test.gradle
@@ -1,4 +1,13 @@
+// The library is compiled to Java 8 bytecode (see build.gradle toolchain), but the
+// test suite can be executed on any installed JDK to verify runtime compatibility.
+// CI passes -PtestJavaVersion=<n> per matrix entry; locally it defaults to 8.
+def testJavaVersion = (project.findProperty('testJavaVersion') ?: '8') as int
+
 tasks.named('test') {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(testJavaVersion)
+    }
+
     testLogging {
         events "passed", "skipped", "failed" //, "standardOut", "standardError"
         showExceptions true


### PR DESCRIPTION
Updates the `/java` library's dependencies and build to the latest versions while keeping the **published library Java 8 compatible** (bytecode major version 52), so existing consumers are unaffected. Releases as **0.3.0**.

## Library (stays Java 8)
- `com.nimbusds:nimbus-jose-jwt` 9.37.3 → **10.9.1**. Nimbus 10.x is a multi-release JAR with a Java 7 base, verified to run on Java 8.
- Migrated `org.bouncycastle:bcpkix-jdk15on:1.70` → **`bcpkix-jdk18on:1.84`** — the `jdk15on` artifact line is end-of-life/deprecated; `jdk18on` still targets Java 8+.
- Gradle wrapper 8.3 → **8.14.5** (+ `distributionSha256Sum`). Stays on 8.x so the build tooling still runs on the older JDKs.
- Updated two test assertions: Nimbus 10.x changed its malformed-JSON error message wording; library behaviour is unchanged.

## webhook-server example (only consumes the Java 8 library)
- `io.javalin:javalin` 4.4.0 → **7.2.2**, example toolchain → **Java 21** (Javalin 7 runs on Jetty 12 / Jakarta EE 10, which requires Java 17+).
- Rewrote route/exception registration for Javalin's config-based API.

## CI: genuinely test on each LTS runtime
Previously the matrix only changed which JDK ran Gradle — because the lib toolchain is pinned to Java 8, the tests always executed on Java 8. Now the test task's launcher follows `-PtestJavaVersion`, so the suite is exercised on each LTS runtime.
- Matrix updated to the current LTS set: **8, 11, 17, 21, 25** (dropped EOL/non-LTS 20, added LTS 25).
- `setup-java` installs Java 8 (compile toolchain), the matrix version (test runtime) and Java 21 last so it runs Gradle (Gradle 8.x can't run on Java 25+, but toolchains let us still test on it).
- Replaced the archived `gradle/wrapper-validation-action` with the maintained `gradle/actions/wrapper-validation@v6.2.0`.
- The `test` task logs the three JVMs it uses at startup — compile toolchain, Gradle daemon (`JAVA_HOME`), and test runtime — so each matrix job's log makes the separation auditable rather than implicit.

## Release
Bumps `version` to **0.3.0** and updates the CHANGELOG (also backfills the missing 0.2.6 entry). Minor bump because the runtime dependency tree changes materially (Nimbus major bump; BouncyCastle artifact migration), even though the public API is unchanged.

> ⚠️ Merging this to `main` will trigger the automatic Maven Central publish + `java-v0.3.0` tag/release, since `gradle.properties` version changed.

## Verification
- Full clean build passes across both toolchains (lib + both examples, Javadoc/sources JARs).
- All five CI matrix legs (8, 11, 17, 21, 25) are green, and the per-job logs confirm the JVM split. Examples: the **Java 25** leg compiles on `1.8.0_492`, runs Gradle on `21.0.11` (`JAVA_HOME` = Temurin 21), and runs tests on `25.0.3+9-LTS`; the **Java 8** leg compiles and tests on `1.8.0_492`. Compile is always Java 8, Gradle is always 21, only the test runtime tracks the matrix.
- webhook-server example boots on Jetty 12 / Java 21 and serves requests against the Java 8 library (POST without `Tl-Signature` → 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
