### PR TITLE
java7: modernise workflow (replace archived wrapper-validation action)

### DIFF
--- a/.github/workflows/java7.yml
+++ b/.github/workflows/java7.yml
@@ -26,6 +26,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
+        # Java 8 only: the library's Java 7 compatibility is guaranteed at compile
+        # time via targetCompatibility = '1.7', and Java 8 is the lowest JDK that can
+        # both run Gradle and execute the tests (Gradle requires Java 8+ to run, and
+        # its toolchains don't support Java 7 as a target), so a real JDK 7 test run
+        # isn't possible here.
         java: [ 8 ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/java7.yml
+++ b/.github/workflows/java7.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
       - name: Validate gradle wrapper
         uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
@@ -78,7 +78,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: gradle
       - name: Validate gradle wrapper
         uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0

--- a/.github/workflows/java7.yml
+++ b/.github/workflows/java7.yml
@@ -26,11 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        # Java 8 only: the library's Java 7 compatibility is guaranteed at compile
-        # time via targetCompatibility = '1.7', and Java 8 is the lowest JDK that can
-        # both run Gradle and execute the tests (Gradle requires Java 8+ to run, and
-        # its toolchains don't support Java 7 as a target), so a real JDK 7 test run
-        # isn't possible here.
+        # Java 8 only: this module compiles to Java 7 bytecode (sourceCompatibility/targetCompatibility = '1.7')
+        # but Gradle 8.x requires a Java 8+ runtime, so CI must run the build/tests on at least JDK 8.
+        # (A real JDK 7 runtime can’t execute the Gradle build/tests here.)
         java: [ 8 ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/java7.yml
+++ b/.github/workflows/java7.yml
@@ -38,7 +38,7 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
+        uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Test
         run: cd java7 && ./gradlew test
 
@@ -81,7 +81,7 @@ jobs:
           distribution: 'adopt'
           cache: gradle
       - name: Validate gradle wrapper
-        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
+        uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Publish to Sonatype and Maven Central
         run: cd java7 && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:


### PR DESCRIPTION
Modernises `.github/workflows/java7.yml`. Workflow-only — no changes to the `java7/` library.

## Changes
- **Replace the archived `gradle/wrapper-validation-action`** with its official successor `gradle/actions/wrapper-validation`, pinned to v6.2.0 (both the build-and-test and publish jobs). The old action's repo is archived and points here.
- **Use the `temurin` distribution instead of the deprecated `adopt` alias** in `actions/setup-java` (matches `java.yml`).
- **Document why the CI matrix is Java 8-only.** Java 7 compatibility is already enforced at compile time via `targetCompatibility = '1.7'`, and Java 8 is the lowest JDK that can both run Gradle and execute the tests (Gradle requires Java 8+ to run, and its toolchains don't support Java 7 as a target) — so a real JDK 7 test run isn't possible. The comment prevents a future well-intentioned "add Java 7" change that would hit the Gradle wall.

## Note
This intentionally does **not** bump java7's Gradle (8.0.2) or add multi-runtime testing — that would be a larger, coordinated change to the `java7/` build files, best as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)