### PR TITLE
java: migrate publishing to Sonatype Central Portal

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -49,36 +49,36 @@ jobs:
       - name: Test on Java ${{ matrix.java-version }}
         run: cd java && ./gradlew test -PtestJavaVersion=${{ matrix.java-version }}
 
-  set-release-version:
-    name: Prepare version to tag and release
+  check-version:
+    name: Check whether the current version is already published
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout current branch
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 2 #we need to make a git diff of the last 2 commits
-      - name: Get project version
-        id: get_project_version
-        run: |
-          cd java && PROJECT_VERSION=$(./gradlew properties | grep "version:" | awk '{print $2}')
-          echo "project_version=$PROJECT_VERSION" >> "$GITHUB_OUTPUT"
-      - name: Get changed version from last two commits
-        id: get_changed_version
-        run: |
-          CHANGED_VERSION=$(git diff HEAD^ -- ./java/gradle.properties | grep +version= | awk -F "=" '{print $2}')
-          echo "changed_version=$CHANGED_VERSION" >> "$GITHUB_OUTPUT"
-      - name: Print changed version from last two commits
-        run: echo ${{ steps.get_changed_version.outputs.changed_version }}
     outputs:
-      project_version: ${{ steps.get_project_version.outputs.project_version }}
-      changed_version: ${{ steps.get_changed_version.outputs.changed_version }}
+      version: ${{ steps.get_version.outputs.version }}
+      is_published: ${{ steps.check_published.outputs.is_published }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Get current version
+        id: get_version
+        run: echo "version=$(grep -m1 '^version=' java/gradle.properties | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+      # Determine whether to publish by querying Maven Central for the artifact at this
+      # version (mirrors the Python workflow's PyPI check), rather than diffing commits.
+      - name: Check if it's already published
+        id: check_published
+        run: |
+          group_path=$(grep -m1 '^group=' java/gradle.properties | cut -d= -f2 | tr '.' '/')
+          artifact=$(grep -m1 '^artifact_id=' java/gradle.properties | cut -d= -f2)
+          version=${{ steps.get_version.outputs.version }}
+          package_url=https://repo1.maven.org/maven2/$group_path/$artifact/$version/$artifact-$version.pom
+          status_code=$(curl --write-out %{http_code} --silent --output /dev/null "$package_url")
+          echo "is_published=$(([ "$status_code" -eq 200 ] && echo true) || echo false)" >> "$GITHUB_OUTPUT"
 
   publish:
     name: Publish to Maven Central
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && needs.set-release-version.outputs.changed_version != ''
-    needs: [build-and-test, set-release-version]
+    # Runs only on main and only when this version isn't already on Maven Central.
+    if: github.ref == 'refs/heads/main' && needs.check-version.outputs.is_published == 'false'
+    needs: [build-and-test, check-version]
     steps:
       - uses: actions/checkout@v7
       # Java 8 for the compile toolchain; 21 last so it runs Gradle.
@@ -103,8 +103,8 @@ jobs:
   create_github_release:
     name: Create Github Release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && !contains(needs.set-release-version.outputs.project_version, 'SNAPSHOT')
-    needs: [publish, set-release-version]
+    if: github.ref == 'refs/heads/main' && !contains(needs.check-version.outputs.version, 'SNAPSHOT')
+    needs: [publish, check-version]
     # Creating a git tag and a GitHub release requires write access to contents.
     permissions:
       contents: write
@@ -114,7 +114,7 @@ jobs:
         uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ needs.set-release-version.outputs.project_version }}
+          custom_tag: ${{ needs.check-version.outputs.version }}
           tag_prefix: 'java-v'
       - name: Create release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -70,13 +70,17 @@ jobs:
           artifact=$(grep -m1 '^artifact_id=' java/gradle.properties | cut -d= -f2)
           version=${{ steps.get_version.outputs.version }}
           package_url=https://repo1.maven.org/maven2/$group_path/$artifact/$version/$artifact-$version.pom
-          # --retry rides out transient network blips so a flake can't fail the workflow.
+          # --retry rides out transient network/5xx blips. Only 404 means "not published";
+          # any other unexpected status fails the job rather than risk a spurious publish.
           status_code=$(curl --retry 3 --write-out '%{http_code}' --silent --output /dev/null "$package_url")
-          if [ "$status_code" = "200" ]; then
-            is_published=true
-          else
-            is_published=false
-          fi
+          case "$status_code" in
+            200) is_published=true ;;
+            404) is_published=false ;;
+            *)
+              echo "Unexpected HTTP $status_code from Maven Central ($package_url)" >&2
+              exit 1
+              ;;
+          esac
           echo "is_published=$is_published" >> "$GITHUB_OUTPUT"
 
   publish:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -75,7 +75,7 @@ jobs:
       changed_version: ${{ steps.get_changed_version.outputs.changed_version }}
 
   publish:
-    name: Publish to Sonatype and Maven Central
+    name: Publish to Maven Central
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && needs.set-release-version.outputs.changed_version != ''
     needs: [build-and-test, set-release-version]
@@ -92,13 +92,13 @@ jobs:
           cache: 'gradle'
       - name: Validate gradle wrapper
         uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-      - name: Publish to Sonatype and Maven Central
-        run: cd java && ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - name: Publish to Maven Central
+        run: cd java && ./gradlew publishToMavenCentral --no-configuration-cache
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_GPG_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
-          SONATYPE_GPG_PASSPHRASE: ${{ secrets.SONATYPE_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SONATYPE_GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SONATYPE_GPG_PASSPHRASE }}
 
   create_github_release:
     name: Create Github Release

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -89,6 +89,12 @@ jobs:
     # Runs only on main and only when this version isn't already on Maven Central.
     if: github.ref == 'refs/heads/main' && needs.check-version.outputs.is_published == 'false'
     needs: [build-and-test, check-version]
+    # Serialize publishes: if a second push to main lands before the first release is
+    # visible on repo1.maven.org, the check-version 404 would otherwise let both run and
+    # race. cancel-in-progress: false lets the in-flight publish finish before the next.
+    concurrency:
+      group: maven-central-publish
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
       # Java 8 for the compile toolchain; 21 last so it runs Gradle.

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -118,7 +118,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SONATYPE_GPG_PASSPHRASE }}
 
   create_github_release:
-    name: Create Github Release
+    name: Create GitHub Release
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && !contains(needs.check-version.outputs.version, 'SNAPSHOT')
     needs: [publish, check-version]

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -86,8 +86,9 @@ jobs:
   publish:
     name: Publish to Maven Central
     runs-on: ubuntu-latest
-    # Runs only on main and only when this version isn't already on Maven Central.
-    if: github.ref == 'refs/heads/main' && needs.check-version.outputs.is_published == 'false'
+    # Runs only on main, only for a non-SNAPSHOT version (Maven Central doesn't host
+    # snapshots, so the check below would always 404), and only when not already published.
+    if: github.ref == 'refs/heads/main' && !contains(needs.check-version.outputs.version, 'SNAPSHOT') && needs.check-version.outputs.is_published == 'false'
     needs: [build-and-test, check-version]
     # Serialize publishes: if a second push to main lands before the first release is
     # visible on repo1.maven.org, the check-version 404 would otherwise let both run and

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -70,8 +70,14 @@ jobs:
           artifact=$(grep -m1 '^artifact_id=' java/gradle.properties | cut -d= -f2)
           version=${{ steps.get_version.outputs.version }}
           package_url=https://repo1.maven.org/maven2/$group_path/$artifact/$version/$artifact-$version.pom
-          status_code=$(curl --write-out %{http_code} --silent --output /dev/null "$package_url")
-          echo "is_published=$(([ "$status_code" -eq 200 ] && echo true) || echo false)" >> "$GITHUB_OUTPUT"
+          # --retry rides out transient network blips so a flake can't fail the workflow.
+          status_code=$(curl --retry 3 --write-out '%{http_code}' --silent --output /dev/null "$package_url")
+          if [ "$status_code" = "200" ]; then
+            is_published=true
+          else
+            is_published=false
+          fi
+          echo "is_published=$is_published" >> "$GITHUB_OUTPUT"
 
   publish:
     name: Publish to Maven Central

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,16 +1,6 @@
 plugins {
-    //    // nexus publishing
-    id "io.github.gradle-nexus.publish-plugin"  version "2.0.0"
-
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl = uri(sonatype_repository_url)
-            snapshotRepositoryUrl = uri(sonatype_snapshot_repository_url)
-            username = System.getenv("SONATYPE_USERNAME")
-            password = System.getenv("SONATYPE_PASSWORD")
-        }
-    }
+    // Publishes directly to the Sonatype Central Portal (central.sonatype.com),
+    // replacing the EOL'd OSSRH / Nexus Repository Manager (s01.oss.sonatype.org).
+    // Pinned here; applied in the :lib project, which produces the published artifact.
+    id "com.vanniktech.maven.publish" version "0.34.0" apply false
 }

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -7,9 +7,6 @@ version=0.3.0
 # locally) are ignored; auto-detection of locally installed JDKs still applies.
 org.gradle.java.installations.fromEnv=JAVA_HOME_8_X64,JAVA_HOME_11_X64,JAVA_HOME_17_X64,JAVA_HOME_21_X64,JAVA_HOME_25_X64
 
-sonatype_repository_url=https://s01.oss.sonatype.org/service/local/
-sonatype_snapshot_repository_url=https://s01.oss.sonatype.org/content/repositories/snapshots/
-
 # Artifacts properties
 artifact_id=truelayer-signing
 project_name=TrueLayer Signing
@@ -18,4 +15,4 @@ project_url=https://github.com/TrueLayer/truelayer-signing
 project_license_url=https://raw.githubusercontent.com/TrueLayer/truelayer-signing/main/LICENSE-MIT
 project_license_name=MIT License
 project_developer=truelayer
-project_scm=scm:git:https://github.com/TrueLayer/truelayer-signing.git˜
+project_scm=scm:git:https://github.com/TrueLayer/truelayer-signing.git

--- a/java/lib/build.gradle
+++ b/java/lib/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
-    id 'maven-publish'
-    id 'signing'
+    // Brings its own maven-publish + signing; publishes to the Sonatype Central Portal.
+    id 'com.vanniktech.maven.publish'
 }
 
 repositories {

--- a/java/lib/publish.gradle
+++ b/java/lib/publish.gradle
@@ -12,7 +12,6 @@ mavenPublishing {
 
     pom {
         name = rootProject.project_name
-        packaging = 'jar'
         description = rootProject.project_description
         url = rootProject.project_url
         scm {

--- a/java/lib/publish.gradle
+++ b/java/lib/publish.gradle
@@ -3,7 +3,9 @@
 // blocks are needed here. For a `java-library` project the plugin auto-configures both the
 // javadoc and sources jars, so no explicit `configure(...)` call is required.
 mavenPublishing {
-    publishToMavenCentral(true)          // host = CENTRAL_PORTAL, automatic release
+    // Targets the Sonatype Central Portal — the plugin's default host since 0.30.x
+    // (OSSRH support is removed) — and automatically releases the deployment.
+    publishToMavenCentral(true)
     signAllPublications()
 
     coordinates(rootProject.group, rootProject.artifact_id, rootProject.version.toString())

--- a/java/lib/publish.gradle
+++ b/java/lib/publish.gradle
@@ -1,48 +1,34 @@
-// Package javadoc and sources
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
+// Publish to the Sonatype Central Portal. The vanniktech plugin owns the javadoc/sources
+// jars and the in-memory PGP signing, so no separate `java {}`/`publishing {}`/`signing {}`
+// blocks are needed here. For a `java-library` project the plugin auto-configures both the
+// javadoc and sources jars, so no explicit `configure(...)` call is required.
+mavenPublishing {
+    publishToMavenCentral(true)          // host = CENTRAL_PORTAL, automatic release
+    signAllPublications()
 
-// Configure publishing repositories and publications
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from(components.java)
+    coordinates(rootProject.group, rootProject.artifact_id, rootProject.version.toString())
 
-            pom {
-                name = rootProject.project_name
-                artifactId = rootProject.artifact_id
-                packaging = 'jar'
-                description = rootProject.project_description
-                url = rootProject.project_url
-                scm {
-                    connection = rootProject.project_scm
-                    developerConnection = rootProject.project_scm
-                    url = rootProject.project_url
-                }
-                licenses {
-                    license {
-                        name = rootProject.project_license_name
-                        url = rootProject.project_license_url
-                    }
-                }
-                developers {
-                    developer {
-                        id = rootProject.project_developer
-                        name = rootProject.project_developer
-                    }
-                }
+    pom {
+        name = rootProject.project_name
+        packaging = 'jar'
+        description = rootProject.project_description
+        url = rootProject.project_url
+        scm {
+            connection = rootProject.project_scm
+            developerConnection = rootProject.project_scm
+            url = rootProject.project_url
+        }
+        licenses {
+            license {
+                name = rootProject.project_license_name
+                url = rootProject.project_license_url
+            }
+        }
+        developers {
+            developer {
+                id = rootProject.project_developer
+                name = rootProject.project_developer
             }
         }
     }
-}
-
-ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
-signing {
-    def signingKey = System.getenv('SONATYPE_GPG_KEY')
-    def signingPassword = System.getenv('SONATYPE_GPG_PASSPHRASE')
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications.mavenJava
-    required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
 }


### PR DESCRIPTION
## Why

The 0.3.0 release in #421 failed to publish. The publish step posts to the legacy OSSRH / Nexus Repository Manager (`s01.oss.sonatype.org`), which Sonatype **EOL'd on 30 June 2025**. It now returns HTTP 402 (`Failed to load staging profiles`), so publishing is permanently broken until we migrate to the new **Sonatype Central Portal**.

This mirrors the migration done in [TrueLayer/truelayer-java#367](https://github.com/TrueLayer/truelayer-java/pull/367).

## What

**Publishing → vanniktech / Central Portal**
- `java/build.gradle`: replace `gradle-nexus.publish-plugin` (+ `nexusPublishing`) with `com.vanniktech.maven.publish` 0.34.0 (declared `apply false`).
- `java/lib/build.gradle`: apply the vanniktech plugin (it brings its own `maven-publish` + `signing`).
- `java/lib/publish.gradle`: replace `publishing`/`signing` blocks with a single `mavenPublishing { publishToMavenCentral(true); signAllPublications() }` (Central Portal is the plugin default since 0.30.x; automatic release). The `java-library` defaults already publish sources + javadoc jars and infer `jar` packaging.
- `java/gradle.properties`: drop the dead OSSRH URLs (and strip a stray char on `project_scm`).
- `.github/workflows/java.yml` publish step: `publishToMavenCentral` with `ORG_GRADLE_PROJECT_mavenCentralUsername/Password` and `ORG_GRADLE_PROJECT_signingInMemoryKey/KeyPassword`.

**Release trigger → hosted-version check (mirrors the Python workflow)**
- Replace the brittle "diff the last two commits for a `version=` change" logic with a `check-version` job that reads the version from `gradle.properties` and GETs the artifact's `.pom` on `repo1.maven.org`: `200` → already published (skip), `404` → publish, any other status → **fail the job** rather than guess. `curl --retry 3` rides out transient blips.
- The `publish` job is additionally gated on a **non-SNAPSHOT** version (Maven Central doesn't host snapshots, so the check would always 404) and serialized with a **`concurrency`** group (`cancel-in-progress: false`) so overlapping `main` pushes can't start racing publishes.
- This unblocks releasing **0.3.0** (verified locally to read as not-published) with no version bump, and makes future releases a plain bump-and-merge.

## Verification

Locally (`publishToMavenLocal` with a throwaway signing key):
- produces signed `jar`, `sources.jar`, `javadoc.jar`, `pom`, and module metadata (all `.asc`);
- POM carries Central-Portal-required metadata (name, description, url, license, scm, developers);
- `:lib:test` passes; Java 8 bytecode toolchain unchanged.

## ⚠️ Required before this can publish (repo secrets)

The old `SONATYPE_USERNAME`/`SONATYPE_PASSWORD` are OSSRH credentials and won't authenticate against the Central Portal. Someone with TrueLayer's Sonatype account must:
1. Log into `central.sonatype.com` → **Generate User Token**, and add it as repo secrets **`MAVEN_CENTRAL_USERNAME`** / **`MAVEN_CENTRAL_PASSWORD`**.
2. Confirm the `com.truelayer` namespace is verified on the Portal (almost certainly already done via truelayer-java#367).

The GPG key/passphrase secrets (`SONATYPE_GPG_KEY` / `SONATYPE_GPG_PASSPHRASE`) are reused as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
